### PR TITLE
Adding initial CMake setup and google tests to confirm toolchain setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /build/
 /out/
 # Visual Studio Code
-/.vscode/
+.vscode/
 
 # Prerequisites
 *.d

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
+# Build files
+/build/
+/out/
+# Visual Studio Code
+/.vscode/
+
 # Prerequisites
 *.d
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /out/
 # Visual Studio Code
 .vscode/
+**/compile_commands.json
 
 # Prerequisites
 *.d

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,13 @@
+### Root CMakeLists.txt for MIPS-Lite project
 cmake_minimum_required(VERSION 3.15)
+
+# Always define toolchain file so we have same setup
+set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/cmake/toolchain.cmake")
+
 project(MIPS-Lite VERSION 0.1.0 LANGUAGES CXX)
 
 # Cmakes built in test runner
 include(CTest)
-
-# Always define toolchain file so we have same setup
-if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
-    message(STATUS "CMAKE_TOOLCHAIN_FILE is not defined. Using default.")
-    set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/cmake/toolchain.cmake")
-else()
-    message(STATUS "CMAKE_TOOLCHAIN_FILE is defined as: ${CMAKE_TOOLCHAIN_FILE}")
-endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.15)
+project(MIPS-Lite VERSION 0.1.0 LANGUAGES CXX)
+
+# Cmakes built in test runner
+include(CTest)
+
+# Always define toolchain file so we have same setup
+if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+    message(STATUS "CMAKE_TOOLCHAIN_FILE is not defined. Using default.")
+    set(CMAKE_TOOLCHAIN_FILE "${CMAKE_SOURCE_DIR}/cmake/toolchain.cmake")
+else()
+    message(STATUS "CMAKE_TOOLCHAIN_FILE is defined as: ${CMAKE_TOOLCHAIN_FILE}")
+endif()
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Ensure C++17 is available
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# Set output directories
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+# Include directories will go here as you add them
+# include_directories(include)
+
+# Create main binary target (will add actual source files later)
+# add_executable(mips_simulator src/main.cpp)
+
+# Enable testing
+enable_testing()
+add_subdirectory(tests/proj-setup)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,60 @@
+{
+    "version": 3,
+    "configurePresets": [
+        {
+            "name": "default",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "toolchainFile": "${sourceDir}/cmake/toolchain.cmake",
+            "cacheVariables": {
+            }
+        },
+        {
+            "name": "Debug",
+            "inherits": "default",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "RelWithDebInfo",
+            "inherits": "default",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+            }
+        },
+        {
+            "name": "Release",
+            "inherits": "default",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "MinSizeRel",
+            "inherits": "default",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "MinSizeRel"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "Debug",
+            "configurePreset": "Debug"
+        },
+        {
+            "name": "RelWithDebInfo",
+            "configurePreset": "RelWithDebInfo"
+        },
+        {
+            "name": "Release",
+            "configurePreset": "Release"
+        },
+        {
+            "name": "MinSizeRel",
+            "configurePreset": "MinSizeRel"
+        }
+    ]
+}

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -1,0 +1,70 @@
+# Simple toolchain file for MIPS Lite Pipeline Simulator
+# TODO: What flags are needed for the MIPS simulator?
+# I've included Claude generate generic ones, and also additional ones
+# that are commented out for now.
+
+# Specify the C++ compiler (adjust as needed for your team)
+set(CMAKE_CXX_COMPILER g++)
+# You could also use: clang++, MSVC (cl.exe), etc.
+
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 17)          # Use C++17 standard
+set(CMAKE_CXX_STANDARD_REQUIRED ON) # Require C++17 support (fail if not available)
+set(CMAKE_CXX_EXTENSIONS OFF)       # Use standard C++17 instead of GNU extensions
+
+# Basic compiler flags
+set(CMAKE_CXX_FLAGS_INIT "-Wall -Wextra")
+# -Wall:  Enable all common warning messages
+# -Wextra: Enable extra warning messages beyond -Wall
+
+set(CMAKE_CXX_FLAGS_DEBUG_INIT "-g")
+# -g: Include debugging information in the executable
+
+set(CMAKE_CXX_FLAGS_RELEASE_INIT "-O2")
+# -O2: Optimize for speed, but not at the expense of binary size
+
+# Additional useful flags (commented out by default)
+# set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wpedantic")
+# -Wpedantic: Issue warnings for non-standard C++ features
+
+# set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Werror")
+# -Werror: Treat warnings as errors (build will fail if warnings are generated)
+
+# set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wshadow")
+# -Wshadow: Warn when a variable declaration shadows another variable
+
+# set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wconversion")
+# -Wconversion: Warn about implicit conversions that may change a value
+
+# set(CMAKE_CXX_FLAGS_INIT "${CMAKE_CXX_FLAGS_INIT} -Wcast-align")
+# -Wcast-align: Warn when a pointer cast increases alignment requirements
+
+# set(CMAKE_CXX_FLAGS_DEBUG_INIT "${CMAKE_CXX_FLAGS_DEBUG_INIT} -fno-omit-frame-pointer")
+# -fno-omit-frame-pointer: Improved debugging at very little cost to performance
+
+# set(CMAKE_CXX_FLAGS_RELEASE_INIT "${CMAKE_CXX_FLAGS_RELEASE_INIT} -O3")
+# -O3: Maximum optimization for speed, potentially larger binary size than -O2
+
+# set(CMAKE_CXX_FLAGS_RELEASE_INIT "${CMAKE_CXX_FLAGS_RELEASE_INIT} -DNDEBUG")
+# -DNDEBUG: Disable assert() macros in release builds for better performance
+
+# set(CMAKE_CXX_FLAGS_RELEASE_INIT "${CMAKE_CXX_FLAGS_RELEASE_INIT} -flto")
+# -flto: Link-time optimization which can improve performance
+
+# set(CMAKE_CXX_FLAGS_MINSIZEREL_INIT "-Os -DNDEBUG")
+# -Os: Optimize for size rather than speed
+
+# set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "-O2 -g -DNDEBUG")
+# Combined optimizations (-O2) with debug info (-g)
+
+# Platform detection for minimal platform-specific settings
+if(WIN32)
+  # Windows-specific settings (if needed)
+
+elseif(APPLE)
+  # macOS-specific settings (if needed)
+
+elseif(UNIX)
+  # Linux-specific settings (if needed)
+
+endif()

--- a/tests/proj-setup/CMakeLists.txt
+++ b/tests/proj-setup/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.15)
+
+# Set up Google Test
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG v1.13.0
+)
+FetchContent_MakeAvailable(googletest)
+
+# Create test executable
+add_executable(setup_test setup_test.cpp)
+
+# Set C++ standard for the test
+target_compile_features(setup_test PRIVATE cxx_std_17)
+
+# Link against Google Test
+target_link_libraries(setup_test PRIVATE gtest gtest_main)
+
+# Register with CTest using Google Test's discovery
+include(GoogleTest)
+gtest_discover_tests(setup_test)

--- a/tests/proj-setup/setup_test.cpp
+++ b/tests/proj-setup/setup_test.cpp
@@ -1,0 +1,60 @@
+#include <gtest/gtest.h>
+#include <vector>
+#include <algorithm>
+#include <string>
+
+// Test C++17 structured bindings
+TEST(Cpp17Features, StructuredBindings) {
+    std::pair<int, std::string> pair = {42, "MIPS"};
+    auto [number, text] = pair;
+
+    EXPECT_EQ(number, 42);
+    EXPECT_EQ(text, "MIPS");
+}
+
+// Test C++17 standard version
+TEST(Cpp17Features, StandardVersion) {
+    EXPECT_GE(__cplusplus, 201703L)
+        << "C++ standard should be at least C++17 (201703L), but got: "
+        << __cplusplus;
+}
+
+// Test constexpr if (will compile only with C++17)
+TEST(Cpp17Features, ConstexprIf) {
+    bool executed = false;
+
+    if constexpr (sizeof(void*) == 8) {
+        // 64-bit system
+        executed = true;
+    } else {
+        // 32-bit system
+        executed = true;
+    }
+
+    EXPECT_TRUE(executed) << "constexpr if statement was not executed";
+}
+
+// Test standard library functionality
+TEST(StandardLibrary, VectorOperations) {
+    std::vector<int> numbers = {4, 8, 15, 16, 23, 42};
+    int sum = 0;
+
+    std::for_each(numbers.begin(), numbers.end(),
+                 [&sum](int n) { sum += n; });
+
+    EXPECT_EQ(sum, 108);
+    EXPECT_EQ(numbers.size(), 6);
+}
+
+// Test that will output information about the environment
+TEST(Environment, Information) {
+    std::cout << "============================================" << std::endl;
+    std::cout << "MIPS-Lite Pipeline Simulator Environment" << std::endl;
+    std::cout << "============================================" << std::endl;
+    std::cout << "C++ Standard: " << __cplusplus << std::endl;
+    std::cout << "Pointer size: " << sizeof(void*) << " bytes" << std::endl;
+    std::cout << "============================================" << std::endl;
+
+    // This will always pass - it's just for information
+    EXPECT_TRUE(true);
+}


### PR DESCRIPTION
# Simulator Project Setup

This PR establishes the initial build infrastructure for our MIPS Lite pipeline simulator project. It includes:
- Basic CMake setup
- Initial test to verify environment setup
- Included test also shows how to use google test for unit testing, these tests can be ran using cmake tools 

Configuring, building, and running tests can all be done from the CMake tools extension
![image](https://github.com/user-attachments/assets/7ecf6b97-3cfc-491c-a88c-0a0a00131cd7)


## VSCode Configuration
I think we are all using vscode so these are the steps I did to get setup. 

1. Install the "CMake Tools" extension
2. Set the CMake path to your system CMake. You can do this by adding the following lines to your `settings.json` file in your vs code workspace:
```json
{
    "cmake.cmakePath": "/usr/bin/cmake",
    "cmake.configureOnOpen": true,
    "cmake.configureSettings" : {
        "Python_EXECUTABLE" : "/usr/bin/python3"
    }
}
```
3. The `.vscode/c_cpp_properties.json` file is included to help IntelliSense find Google Test headers. Here's what my file looks like. You will likely need to change this slightly for your system:
```json 
{
    "configurations": [
        {
            "name": "Linux",
            "includePath": [
                "${workspaceFolder}/**",
                "${workspaceFolder}/build/_deps/googletest-src/googletest/include"
            ],
            "defines": [],
            "compilerPath": "/usr/bin/g++",
            "cStandard": "c11",
            "cppStandard": "c++17",
            "intelliSenseMode": "linux-gcc-x64",
            "compileCommands": "${workspaceFolder}/build/compile_commands.json"
        }
    ],
    "version": 4
}
```

