### PR TITLE
Instruction classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,8 @@ FetchContent_MakeAvailable(googletest)
 
 set(SOURCE_FILES
     src/mips_mem_parser.cpp
+    src/mips_instruction.cpp
+    src/stats.cpp
 )
 
 # Create the library that will be used by tests and main executable
@@ -51,3 +53,4 @@ enable_testing()
 add_subdirectory(tests/proj_setup)
 add_subdirectory(tests/mem_parser)
 add_subdirectory(tests/libs)
+add_subdirectory(tests/mips_instruction)

--- a/include/mips_instruction.h
+++ b/include/mips_instruction.h
@@ -1,0 +1,40 @@
+#pragma once
+#include <sys/types.h>
+
+#include <cstdint>
+#include <optional>
+
+#include "mips_lite_defs.h"
+
+class Instruction {
+   private:
+    uint32_t instruction_;
+    uint8_t opcode_;                    // The opcode of the instruction
+    uint8_t rs_;                        // Source register
+    uint8_t rt_;                        // Target register or second source register
+    std::optional<uint8_t> rd_;         // Destination register (only for R-type)
+    std::optional<int32_t> immediate_;  // Sign extended immediate value (only for I-type)
+    uint16_t control_word_;  // Control word for the instruction TODO: Do we need this here?
+    mips_lite::InstructionType instruction_type_;  // Type of instruction (R, I)
+
+   public:
+    explicit Instruction(uint32_t instruction);
+    ~Instruction() = default;  // TODO: Is this correct? Any other destructor needed?
+
+    // Getters
+    uint8_t getOpcode() const { return opcode_; }
+    uint8_t getRs() const { return rs_; }
+    uint8_t getRt() const { return rt_; }
+
+    // Getters for optional fields
+    bool hasRd() const { return rd_.has_value(); }
+    uint8_t getRd() const { return rd_.value_or(0); }  // Returns 0 if not present
+    bool hasImmediate() const { return immediate_.has_value(); }
+    int32_t getImmediate() const { return immediate_.value_or(0); }  // Returns 0 if not present
+    // Other getters
+    uint32_t getInstruction() const { return instruction_; }
+    mips_lite::InstructionType getInstructionType() const { return instruction_type_; }
+    uint16_t getControlWord() const { return control_word_; }
+    // Helper to check HALT instruction
+    bool isHaltInstruction() const { return opcode_ == mips_lite::opcode::HALT; }
+};

--- a/include/mips_lite_defs.h
+++ b/include/mips_lite_defs.h
@@ -66,13 +66,21 @@ inline uint32_t extract_bits(uint32_t value, int start, int length) {
 }
 
 // Instruction Field Extraction Functions
-inline uint8_t get_opcode(uint32_t instruction) { return extract_bits(instruction, 26, 6); }
+inline uint8_t get_opcode(uint32_t instruction) {
+    return static_cast<uint8_t>(extract_bits(instruction, 26, 6));
+}
 
-inline uint8_t get_rs(uint32_t instruction) { return extract_bits(instruction, 21, 5); }
+inline uint8_t get_rs(uint32_t instruction) {
+    return static_cast<uint8_t>(extract_bits(instruction, 21, 5));
+}
 
-inline uint8_t get_rt(uint32_t instruction) { return extract_bits(instruction, 16, 5); }
+inline uint8_t get_rt(uint32_t instruction) {
+    return static_cast<uint8_t>(extract_bits(instruction, 16, 5));
+}
 
-inline uint8_t get_rd(uint32_t instruction) { return extract_bits(instruction, 11, 5); }
+inline uint8_t get_rd(uint32_t instruction) {
+    return static_cast<uint8_t>(extract_bits(instruction, 11, 5));
+}
 
 inline int16_t get_immediate(uint32_t instruction) {
     // Extract 16-bit immediate value and sign-extend it
@@ -97,6 +105,119 @@ inline InstructionType get_instruction_type(uint8_t opcode) {
         default:
             return InstructionType::I_TYPE;
     }
+}
+// Control Word Bit Positions
+// Control Word Bit Positions
+namespace control {
+// Example control signals - adjust based on your specific datapath
+constexpr uint16_t REG_DST = 0x0001;     // 0: RT as destination, 1: RD as destination
+constexpr uint16_t ALU_SRC = 0x0002;     // 0: Register, 1: Immediate
+constexpr uint16_t MEM_TO_REG = 0x0004;  // 0: ALU result, 1: Memory data
+constexpr uint16_t REG_WRITE = 0x0008;   // 0: No write, 1: Write to register
+constexpr uint16_t MEM_READ = 0x0010;    // 0: No read, 1: Read from memory
+constexpr uint16_t MEM_WRITE = 0x0020;   // 0: No write, 1: Write to memory
+constexpr uint16_t BRANCH = 0x0040;      // 0: No branch, 1: Branch
+constexpr uint16_t JUMP = 0x0080;        // 0: No jump, 1: Jump
+
+// ALU operation codes (4 bits for operation selection)
+constexpr uint16_t ALU_OP_ADD = 0x0000;   // Addition
+constexpr uint16_t ALU_OP_SUB = 0x0100;   // Subtraction
+constexpr uint16_t ALU_OP_MUL = 0x0200;   // Multiplication
+constexpr uint16_t ALU_OP_OR = 0x0300;    // Logical OR
+constexpr uint16_t ALU_OP_AND = 0x0400;   // Logical AND
+constexpr uint16_t ALU_OP_XOR = 0x0500;   // Logical XOR
+constexpr uint16_t ALU_OP_MASK = 0x0F00;  // Mask for ALU operation bits
+}  // namespace control
+
+// Function to get control word based on opcode
+inline uint16_t get_control_word(uint8_t opcode) {
+    uint16_t control_word = 0;
+
+    switch (opcode) {
+        // R-type arithmetic operations
+        case opcode::ADD:
+            control_word = control::REG_DST | control::REG_WRITE | control::ALU_OP_ADD;
+            break;
+        case opcode::SUB:
+            control_word = control::REG_DST | control::REG_WRITE | control::ALU_OP_SUB;
+            break;
+        case opcode::MUL:
+            control_word = control::REG_DST | control::REG_WRITE | control::ALU_OP_MUL;
+            break;
+
+        // I-type arithmetic operations
+        case opcode::ADDI:
+            control_word = control::ALU_SRC | control::REG_WRITE | control::ALU_OP_ADD;
+            break;
+        case opcode::SUBI:
+            control_word = control::ALU_SRC | control::REG_WRITE | control::ALU_OP_SUB;
+            break;
+        case opcode::MULI:
+            control_word = control::ALU_SRC | control::REG_WRITE | control::ALU_OP_MUL;
+            break;
+
+        // R-type logical operations
+        case opcode::OR:
+            control_word = control::REG_DST | control::REG_WRITE | control::ALU_OP_OR;
+            break;
+        case opcode::AND:
+            control_word = control::REG_DST | control::REG_WRITE | control::ALU_OP_AND;
+            break;
+        case opcode::XOR:
+            control_word = control::REG_DST | control::REG_WRITE | control::ALU_OP_XOR;
+            break;
+
+        // I-type logical operations
+        case opcode::ORI:
+            control_word = control::ALU_SRC | control::REG_WRITE | control::ALU_OP_OR;
+            break;
+        case opcode::ANDI:
+            control_word = control::ALU_SRC | control::REG_WRITE | control::ALU_OP_AND;
+            break;
+        case opcode::XORI:
+            control_word = control::ALU_SRC | control::REG_WRITE | control::ALU_OP_XOR;
+            break;
+
+        // Memory access operations
+        case opcode::LDW:
+            control_word = control::ALU_SRC | control::MEM_READ | control::MEM_TO_REG |
+                           control::REG_WRITE | control::ALU_OP_ADD;
+            break;
+        case opcode::STW:
+            control_word = control::ALU_SRC | control::MEM_WRITE | control::ALU_OP_ADD;
+            break;
+
+        // Control flow operations
+        case opcode::BZ:
+            control_word = control::ALU_SRC | control::BRANCH | control::ALU_OP_SUB;
+            break;
+        case opcode::BEQ:
+            control_word = control::BRANCH | control::ALU_OP_SUB;
+            break;
+        case opcode::JR:
+            control_word = control::JUMP;
+            break;
+        case opcode::HALT:
+            // No control signals needed for HALT
+            break;
+
+        default:
+            // Invalid opcode
+            break;
+    }
+
+    return control_word;
+}
+
+// Helper functions for control flow instructions
+inline bool is_branch_instruction(uint8_t opcode) {
+    return opcode == opcode::BZ || opcode == opcode::BEQ;
+}
+
+inline bool is_jump_instruction(uint8_t opcode) { return opcode == opcode::JR; }
+
+inline bool is_memory_instruction(uint8_t opcode) {
+    return opcode == opcode::LDW || opcode == opcode::STW;
 }
 
 }  // namespace mips_lite

--- a/src/mips_instruction.cpp
+++ b/src/mips_instruction.cpp
@@ -1,0 +1,22 @@
+#include "mips_instruction.h"
+
+#include <cstdint>
+
+Instruction::Instruction(uint32_t instruction) : instruction_(instruction) {
+    opcode_ = mips_lite::get_opcode(instruction_);
+    instruction_type_ = mips_lite::get_instruction_type(opcode_);
+    rs_ = mips_lite::get_rs(instruction_);
+    rt_ = mips_lite::get_rt(instruction_);
+
+    // Control word generation
+    control_word_ = mips_lite::get_control_word(opcode_);
+
+    if (instruction_type_ == mips_lite::InstructionType::R_TYPE) {
+        // R-type instructions
+        rd_ = mips_lite::get_rd(instruction_);
+        // For R-type, immediate and address remain uninitialized (std::nullopt)
+    } else {
+        // I-type instructions
+        immediate_ = static_cast<int32_t>(mips_lite::get_immediate(instruction_));
+    }
+}

--- a/tests/mips_instruction/CMakeLists.txt
+++ b/tests/mips_instruction/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Create test executable for memory parser
+set(TEST_NAME  mips_instruction_test)
+add_executable(${TEST_NAME} mips_instruction_tests.cpp)
+
+# Set C++ standard for the test (redundant but kept for clarity)
+target_compile_features(${TEST_NAME} PRIVATE cxx_std_17)
+
+# Link against Google Test and the main project library
+target_link_libraries(${TEST_NAME}
+    PRIVATE
+    gtest
+    gtest_main
+    mips_lite_lib
+)
+
+# Register with CTest using Google Test's discovery
+include(GoogleTest)
+gtest_discover_tests(${TEST_NAME})

--- a/tests/mips_instruction/mips_instruction_tests.cpp
+++ b/tests/mips_instruction/mips_instruction_tests.cpp
@@ -1,0 +1,158 @@
+/**
+ * @file mips_instruction_tests.cpp
+ * @brief Unit tests for Instruction class
+ */
+
+#include <gtest/gtest.h>
+#include <sys/types.h>
+
+#include <cstdint>
+#include <optional>
+
+#include "mips_instruction.h"
+#include "mips_lite_defs.h"
+
+class InstructionTest : public ::testing::Test {
+   protected:
+    // Sample instructions to use in tests
+    // R-type: ADD $rd, $rs, $rt (opcode=0, rs=1, rt=2, rd=3)
+    const uint32_t r_type_add_instr = 0x00221800;  // ADD $3, $1, $2
+
+    // I-type: ADDI $rt, $rs, immediate (opcode=1, rs=4, rt=5, imm=100)
+    const uint32_t i_type_addi_pos_instr = 0x04850064;  // ADDI $5, $4, 100
+
+    // I-type with negative immediate: ADDI $rt, $rs, immediate (opcode=1, rs=6, rt=7, imm=-100)
+    const uint32_t i_type_addi_neg_instr = 0x04C7FF9C;  // ADDI $7, $6, -100
+
+    // I-type memory: LDW $rt, imm($rs) (opcode=12, rs=8, rt=9, imm=200)
+    const uint32_t i_type_ldw_instr = 0x310900C8;  // LDW $9, 200($8)
+
+    // I-type branch: BEQ $rs, $rt, imm (opcode=15, rs=10, rt=11, imm=-50)
+    const uint32_t i_type_beq_instr = 0x3D4BFFCE;  // BEQ $10, $11, -50
+};
+
+// Test R-type instruction construction
+TEST_F(InstructionTest, RTypeAddInstruction) {
+    Instruction instr(r_type_add_instr);
+
+    // Verify instruction type
+    EXPECT_EQ(instr.getInstructionType(), mips_lite::InstructionType::R_TYPE);
+
+    // Verify opcode
+    EXPECT_EQ(instr.getOpcode(), mips_lite::opcode::ADD);
+
+    // Verify registers
+    EXPECT_EQ(instr.getRs(), 1);
+    EXPECT_EQ(instr.getRt(), 2);
+    EXPECT_TRUE(instr.hasRd());
+    EXPECT_EQ(instr.getRd(), 3);
+
+    // Verify immediate is not set for R-type
+    EXPECT_FALSE(instr.hasImmediate());
+
+    // Verify control word
+    uint32_t expected_control = mips_lite::control::REG_DST | mips_lite::control::REG_WRITE |
+                                mips_lite::control::ALU_OP_ADD;
+    EXPECT_EQ(instr.getControlWord(), expected_control);
+}
+
+// Test I-type instruction with positive immediate
+TEST_F(InstructionTest, ITypeInstructionPositiveImmediate) {
+    Instruction instr(i_type_addi_pos_instr);
+
+    // Verify instruction type
+    EXPECT_EQ(instr.getInstructionType(), mips_lite::InstructionType::I_TYPE);
+
+    // Verify opcode
+    EXPECT_EQ(instr.getOpcode(), mips_lite::opcode::ADDI);
+
+    // Verify registers
+    EXPECT_EQ(instr.getRs(), 4);
+    EXPECT_EQ(instr.getRt(), 5);
+    EXPECT_FALSE(instr.hasRd());  // No rd in I-type
+
+    // Verify immediate
+    EXPECT_TRUE(instr.hasImmediate());
+    EXPECT_EQ(instr.getImmediate(), 100);
+
+    // Verify control word
+    uint32_t expected_control = mips_lite::control::ALU_SRC | mips_lite::control::REG_WRITE |
+                                mips_lite::control::ALU_OP_ADD;
+    EXPECT_EQ(instr.getControlWord(), expected_control);
+}
+
+// Test I-type instruction with negative immediate (sign extension)
+TEST_F(InstructionTest, ITypeInstructionNegativeImmediate) {
+    Instruction instr(i_type_addi_neg_instr);
+
+    // Verify instruction type
+    EXPECT_EQ(instr.getInstructionType(), mips_lite::InstructionType::I_TYPE);
+
+    // Verify opcode
+    EXPECT_EQ(instr.getOpcode(), mips_lite::opcode::ADDI);
+
+    // Verify registers
+    EXPECT_EQ(instr.getRs(), 6);
+    EXPECT_EQ(instr.getRt(), 7);
+
+    // Verify immediate with sign extension
+    EXPECT_TRUE(instr.hasImmediate());
+    EXPECT_EQ(instr.getImmediate(), -100);
+
+    // Verify the sign extension worked correctly by checking bit pattern
+    // -100 in 32-bit two's complement should have upper 16 bits all set to 1
+    uint32_t imm_value = static_cast<uint32_t>(instr.getImmediate());
+    EXPECT_EQ(imm_value & 0xFFFF0000, 0xFFFF0000) << "Sign extension failed";
+}
+
+// Test Memory access I-type instruction
+TEST_F(InstructionTest, MemoryInstructionLDW) {
+    Instruction instr(i_type_ldw_instr);
+
+    // Verify instruction type
+    EXPECT_EQ(instr.getInstructionType(), mips_lite::InstructionType::I_TYPE);
+
+    // Verify opcode
+    EXPECT_EQ(instr.getOpcode(), mips_lite::opcode::LDW);
+
+    // Verify registers
+    EXPECT_EQ(instr.getRs(), 8);
+    EXPECT_EQ(instr.getRt(), 9);
+
+    // Verify immediate
+    EXPECT_TRUE(instr.hasImmediate());
+    EXPECT_EQ(instr.getImmediate(), 200);
+
+    // Verify control word for memory load
+    uint32_t expected_control = mips_lite::control::ALU_SRC | mips_lite::control::MEM_READ |
+                                mips_lite::control::MEM_TO_REG | mips_lite::control::REG_WRITE |
+                                mips_lite::control::ALU_OP_ADD;
+    EXPECT_EQ(instr.getControlWord(), expected_control);
+}
+
+// Test Branch I-type instruction with negative offset
+TEST_F(InstructionTest, BranchInstructionBEQ) {
+    Instruction instr(i_type_beq_instr);
+
+    // Verify instruction type
+    EXPECT_EQ(instr.getInstructionType(), mips_lite::InstructionType::I_TYPE);
+
+    // Verify opcode
+    EXPECT_EQ(instr.getOpcode(), mips_lite::opcode::BEQ);
+
+    // Verify registers
+    EXPECT_EQ(instr.getRs(), 10);
+    EXPECT_EQ(instr.getRt(), 11);
+
+    // Verify immediate with sign extension
+    EXPECT_TRUE(instr.hasImmediate());
+    EXPECT_EQ(instr.getImmediate(), -50);
+
+    // Verify the sign extension worked correctly
+    uint32_t imm_value = static_cast<uint32_t>(instr.getImmediate());
+    EXPECT_EQ(imm_value & 0xFFFF0000, 0xFFFF0000) << "Sign extension failed";
+
+    // Verify control word for branch
+    uint32_t expected_control = mips_lite::control::BRANCH | mips_lite::control::ALU_OP_SUB;
+    EXPECT_EQ(instr.getControlWord(), expected_control);
+}


### PR DESCRIPTION
Adding an instruction class, which is largely a data class. It closely follows the draw.io diagram Nik created. My one addition is that I added a `control_word_` data member to this class, and respectively, expanded the `mips_lite_defs.h` with control word logic. This new logic simply constructs the control word given an opcode.  I've included tests for these new additions, and they all pass. 

For easy reference, the control word logic is broken down as such:

Bit(s) | Signal Name | Value 0 | Value 1 | Purpose
-- | -- | -- | -- | --
11-8 | ALUOp | Various operation codes |   | Selects ALU operation (ADD=0x0, SUB=0x1, MUL=0x2, OR=0x3, AND=0x4, XOR=0x5)
7 | Jump | No jump | Jump | Controls if PC takes jump target address
6 | Branch | No branch | Branch | Controls if branch condition is evaluated
5 | MemWrite | No write | Write | Controls if data memory is written to
4 | MemRead | No read | Read | Controls if data memory is read from
3 | RegWrite | No write | Write | Controls if register file is written to
2 | MemtoReg | ALU result | Memory data | Selects what data is written to register file
1 | ALUSrc | Register | Immediate | Selects second operand for ALU (reg or immediate)
0 | RegDst | RT | RD | Selects destination register (RT or RD)
