### PR TITLE
Add basic functional simulator class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(googletest)
 
 set(SOURCE_FILES
+    src/functional_simulator.cpp
     src/mips_mem_parser.cpp
     src/mips_instruction.cpp
     src/stats.cpp
@@ -52,3 +53,4 @@ add_subdirectory(tests/mem_parser)
 add_subdirectory(tests/libs)
 add_subdirectory(tests/mips_instruction)
 add_subdirectory(tests/reg_type)
+add_subdirectory(tests/functional_simulator)

--- a/include/functional_simulator.h
+++ b/include/functional_simulator.h
@@ -3,7 +3,7 @@
 #include <array>
 #include <cstdint>
 
-#include "mips_mem_parser.h"
+#include "memory_interface.h"
 #include "register_file.h"
 #include "stats.h"
 
@@ -28,7 +28,7 @@ class FunctionalSimulator {
      * @param mem Pointer to the MemoryParser instance.
      * @param enable_forwarding Optional flag to enable data forwarding.
      */
-    FunctionalSimulator(RegisterFile* rf, Stats* st, MemoryParser* mem,
+    FunctionalSimulator(RegisterFile* rf, Stats* st, IMemoryParser* mem,
                         bool enable_forwarding = false);
 
     // Getter methods
@@ -123,5 +123,5 @@ class FunctionalSimulator {
     uint8_t stall;
 
     /// Serves as the simulator memory
-    MemoryParser* memory_parser;
+    IMemoryParser* memory_parser;
 };

--- a/include/functional_simulator.h
+++ b/include/functional_simulator.h
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstdint>
+#include <optional>
 
 #include "memory_interface.h"
 #include "reg_type.h"
@@ -10,6 +11,20 @@
 
 // Forward declarations of Instruction class
 class Instruction;
+
+/**
+ * @struct PipelineData
+ * @brief Holds intermediate pipeline data passed between stages.
+ *
+ * This includes:
+ * - `result`: an intermediate value (e.g., ALU result or memory load)
+ * - `wb_reg`: the destination register number to write to in the WB stage, if any
+ */
+template <typename T>
+struct PipelineData {
+    T result;                       ///< Intermediate result to be forwarded or written
+    std::optional<uint8_t> wb_reg;  ///< Destination register number (std::nullopt if N/A)
+};
 
 /**
  * @class FunctionalSimulator
@@ -113,17 +128,16 @@ class FunctionalSimulator {
     void clockPipelineRegisters();
 
     /**
-     * @brief Pipeline registers between each stage. Each register holds a full
-     *        register file in order to allow named access of register data
-     *        between stages.
+     * @brief Pipeline registers between each stage. Each register holds intermediate
+     *        values and target write-back registers.
      *
      * These are intended to model the flow of decoded operand values and intermediate
      * results between pipeline stages, enabling inspection or forwarding by register number.
      */
-    reg<RegisterFile> ifid_reg;   ///< Between instruction fetch and decode
-    reg<RegisterFile> idex_reg;   ///< Between decode and execute
-    reg<RegisterFile> exmem_reg;  ///< Between execute and memory
-    reg<RegisterFile> memwb_reg;  ///< Between memory and writeback
+    reg<PipelineData<uint32_t> > ifid_reg;   ///< Between instruction fetch and decode
+    reg<PipelineData<uint32_t> > idex_reg;   ///< Between decode and execute
+    reg<PipelineData<uint32_t> > exmem_reg;  ///< Between execute and memory
+    reg<PipelineData<uint32_t> > memwb_reg;  ///< Between memory and writeback
 
    private:
     /// Program Counter

--- a/include/functional_simulator.h
+++ b/include/functional_simulator.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+
+#include "mips_mem_parser.h"
+#include "register_file.h"
+#include "stats.h"
+
+// Forward declarations of Instruction class
+class Instruction;
+
+/**
+ * @class FunctionalSimulator
+ * @brief Simulates a simplified MIPS pipelined processor with optional data forwarding.
+ *
+ * This class is constructed using dependency injection to supply instances of
+ * RegisterFile, Stats, and MemoryParser. Upon construction, the simulator sets
+ * the program counter to 0, disables forwarding by default, clears the pipeline,
+ * and resets the stall counter.
+ */
+class FunctionalSimulator {
+   public:
+    /**
+     * @brief Constructor using dependency injection.
+     * @param rf Pointer to the RegisterFile instance.
+     * @param st Pointer to the Stats instance.
+     * @param mem Pointer to the MemoryParser instance.
+     * @param enable_forwarding Optional flag to enable data forwarding.
+     */
+    FunctionalSimulator(RegisterFile* rf, Stats* st, MemoryParser* mem,
+                        bool enable_forwarding = false);
+
+    // Getter methods
+
+    /**
+     * @brief Get the current Program Counter.
+     * @return Current PC value.
+     */
+    uint32_t getPC() const;
+
+    /**
+     * @brief Check if forwarding is enabled.
+     * @return True if forwarding is enabled.
+     */
+    bool isForwardingEnabled() const;
+
+    /**
+     * @brief Get the current stall count.
+     * @return Number of remaining stall cycles.
+     */
+    uint8_t getStall() const;
+
+    /**
+     * @brief Get the instruction pointer at the given pipeline stage.
+     * @param stage Index (0 to 4) of the pipeline stage.
+     * @return Instruction pointer at that stage, or nullptr if uninitialized.
+     */
+    Instruction* getPipelineStage(int stage) const;
+
+    // Setter methods
+
+    /**
+     * @brief Set the Program Counter.
+     * @param new_pc New value for the PC.
+     */
+    void setPC(uint32_t new_pc);
+
+    /**
+     * @brief Set the number of stall cycles.
+     * @param cycles Number of stall cycles.
+     */
+    void setStall(uint8_t cycles);
+
+    // Pipeline stage methods
+
+    /**
+     * @brief Fetch the next instruction.
+     */
+    void instructionFetch();
+
+    /**
+     * @brief Decode by reading registers referenced by the instruction.
+     * @param instr Pointer to the instruction to decode.
+     */
+    void instructionDecode(Instruction* instr);
+
+    /**
+     * @brief Execute by performing ALU operation from the instruction.
+     * @param instr Pointer to the instruction to execute.
+     */
+    void execute(Instruction* instr);
+
+    /**
+     * @brief Perform memory access for the instruction.
+     * @param instr Pointer to the instruction.
+     */
+    void memory(Instruction* instr);
+
+    /**
+     * @brief Write the result back to the register file.
+     * @param instr Pointer to the instruction.
+     */
+    void writeBack(Instruction* instr);
+
+   private:
+    /// Program Counter
+    uint32_t pc;
+
+    /// General purpose registers
+    RegisterFile* register_file;
+
+    /// 5-stage pipeline of instruction pointers
+    std::array<Instruction*, 5> pipeline;
+
+    /// Stats instance to track runtime metrics
+    Stats* stats;
+
+    /// Whether or not data forwarding is enabled
+    bool forward;
+
+    /// Countdown of the required stall cycles
+    uint8_t stall;
+
+    /// Serves as the simulator memory
+    MemoryParser* memory_parser;
+};

--- a/include/functional_simulator.h
+++ b/include/functional_simulator.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 
 #include "memory_interface.h"
+#include "reg_type.h"
 #include "register_file.h"
 #include "stats.h"
 
@@ -102,6 +103,27 @@ class FunctionalSimulator {
      * @param instr Pointer to the instruction.
      */
     void writeBack(Instruction* instr);
+
+    /**
+     * @brief Advance all pipeline registers by one cycle.
+     *
+     * This clocks each pipeline register, promoting its next value to current.
+     * Should be called at the end of each simulation cycle.
+     */
+    void clockPipelineRegisters();
+
+    /**
+     * @brief Pipeline registers between each stage. Each register holds a full
+     *        register file in order to allow named access of register data
+     *        between stages.
+     *
+     * These are intended to model the flow of decoded operand values and intermediate
+     * results between pipeline stages, enabling inspection or forwarding by register number.
+     */
+    reg<RegisterFile> ifid_reg;   ///< Between instruction fetch and decode
+    reg<RegisterFile> idex_reg;   ///< Between decode and execute
+    reg<RegisterFile> exmem_reg;  ///< Between execute and memory
+    reg<RegisterFile> memwb_reg;  ///< Between memory and writeback
 
    private:
     /// Program Counter

--- a/include/functional_simulator.h
+++ b/include/functional_simulator.h
@@ -116,12 +116,12 @@ class FunctionalSimulator {
     /// Stats instance to track runtime metrics
     Stats* stats;
 
+    /// Serves as the simulator memory
+    IMemoryParser* memory_parser;
+
     /// Whether or not data forwarding is enabled
     bool forward;
 
     /// Countdown of the required stall cycles
     uint8_t stall;
-
-    /// Serves as the simulator memory
-    IMemoryParser* memory_parser;
 };

--- a/include/memory_interface.h
+++ b/include/memory_interface.h
@@ -1,0 +1,48 @@
+/**
+ * @file memory_interface.h
+ * @brief Abstract memory access interface for use in processor simulation.
+ *
+ * This interface defines the contract for memory read and write operations.
+ *
+ * It is especially useful for dependency injection in unit testing,
+ * where a mock implementation (e.g. using Google Mock) can simulate
+ * memory behavior without relying on file I/O or large memory state.
+ *
+ * Typical use cases include:
+ *  - Injecting test memory into a functional simulator
+ *  - Verifying memory interactions using EXPECT_CALL
+ *  - Avoiding file-based initialization (e.g. MemoryParser constructor)
+ *
+ */
+
+#pragma once
+
+#include <cstdint>
+
+/**
+ * @interface IMemoryParser
+ * @brief Abstract interface for memory access to support mocking in tests.
+ */
+class IMemoryParser {
+   public:
+    virtual ~IMemoryParser() = default;
+
+    /**
+     * @brief Read an instruction from the given address.
+     * @param address Memory address to read from.
+     * @return 32-bit instruction.
+     */
+    virtual uint32_t readInstruction(uint32_t address) = 0;
+    /**
+     * @brief Read a 32-bit value from memory.
+     * @param address Memory address to read.
+     * @return 32-bit value.
+     */
+    virtual uint32_t readMemory(uint32_t address) = 0;
+    /**
+     * @brief Write a 32-bit value to memory.
+     * @param address Memory address to write.
+     * @param value 32-bit value to write.
+     */
+    virtual void writeMemory(uint32_t address, uint32_t value) = 0;
+};

--- a/include/mips_mem_parser.h
+++ b/include/mips_mem_parser.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include "memory_interface.h"
 #include "mips_lite_defs.h"
 
 constexpr uint32_t ADDR_TO_INDEX(uint32_t addr) { return (addr >> 2); }
@@ -26,7 +27,7 @@ constexpr uint32_t INDEX_TO_ADDR(uint32_t index) { return (index << 2); }
 constexpr uint32_t MAX_MEMORY_SIZE = 4096;  // Maximum memory size in bytes (4 KiB)
 constexpr uint32_t MAX_VEC_SIZE = (MAX_MEMORY_SIZE / mips_lite::WORD_SIZE);
 
-class MemoryParser {
+class MemoryParser : public IMemoryParser {
    private:
     std::string input_filename_;            // Input file to read from
     std::string output_filename_;           // Output file to write to
@@ -45,10 +46,10 @@ class MemoryParser {
                           const std::string& output_filename = "");
     ~MemoryParser();
 
-    uint32_t readInstruction(uint32_t address);          // Instruction Access
-    uint32_t readMemory(uint32_t address);               // Data Memory Access
-    void writeMemory(uint32_t address, uint32_t value);  // Data Memory Access
-    void printMemoryContent();                           // For debugging
+    uint32_t readInstruction(uint32_t address) override;          // Instruction Access
+    uint32_t readMemory(uint32_t address) override;               // Data Memory Access
+    void writeMemory(uint32_t address, uint32_t value) override;  // Data Memory Access
+    void printMemoryContent();                                    // For debugging
 
     // Getters
     std::string getInputFilename() const { return input_filename_; }

--- a/src/functional_simulator.cpp
+++ b/src/functional_simulator.cpp
@@ -1,0 +1,63 @@
+#include "functional_simulator.h"
+
+#include "mips_instruction.h"
+#include "mips_mem_parser.h"
+#include "register_file.h"
+#include "stats.h"
+
+FunctionalSimulator::FunctionalSimulator(RegisterFile* rf, Stats* st, MemoryParser* mem,
+                                         bool enable_forwarding)
+    : pc(0),
+      register_file(rf),
+      stats(st),
+      memory_parser(mem),
+      forward(enable_forwarding),
+      stall(0) {
+    for (auto& stage : pipeline) {
+        stage = nullptr;
+    }
+}
+
+uint32_t FunctionalSimulator::getPC() const { return pc; }
+
+bool FunctionalSimulator::isForwardingEnabled() const { return forward; }
+
+uint8_t FunctionalSimulator::getStall() const { return stall; }
+
+Instruction* FunctionalSimulator::getPipelineStage(int stage) const {
+    if (stage < 0 || stage >= 5) {
+        throw std::out_of_range("Pipeline stage index out of range");
+    }
+    return pipeline[stage];
+}
+
+void FunctionalSimulator::setPC(uint32_t new_pc) { pc = new_pc; }
+
+void FunctionalSimulator::setStall(uint8_t cycles) { stall = cycles; }
+
+void FunctionalSimulator::instructionFetch() {
+    // Stub: Should first check stall count to determine if a null pointer should be inserted
+    // Otherwise, fetch instruction at PC using memory_parser and insert into pipeline[0],
+    // then update PC by word size
+}
+
+void FunctionalSimulator::instructionDecode(Instruction* instr) {
+    // Stub: Decode the instruction (parse operands, maybe identify hazards)
+    // Set dirty bit on registers which will be written back to later
+    (void)instr;  // Silence unused parameter warning
+}
+
+void FunctionalSimulator::execute(Instruction* instr) {
+    // Stub: Perform ALU operation specified or calculate branch effective address
+    (void)instr;
+}
+
+void FunctionalSimulator::memory(Instruction* instr) {
+    // Stub: Access memory if needed (load or store only)
+    (void)instr;
+}
+
+void FunctionalSimulator::writeBack(Instruction* instr) {
+    // Stub: Write result back to register file, clear dirty bit
+    (void)instr;
+}

--- a/src/functional_simulator.cpp
+++ b/src/functional_simulator.cpp
@@ -1,11 +1,11 @@
 #include "functional_simulator.h"
 
+#include "memory_interface.h"
 #include "mips_instruction.h"
-#include "mips_mem_parser.h"
 #include "register_file.h"
 #include "stats.h"
 
-FunctionalSimulator::FunctionalSimulator(RegisterFile* rf, Stats* st, MemoryParser* mem,
+FunctionalSimulator::FunctionalSimulator(RegisterFile* rf, Stats* st, IMemoryParser* mem,
                                          bool enable_forwarding)
     : pc(0),
       register_file(rf),

--- a/src/functional_simulator.cpp
+++ b/src/functional_simulator.cpp
@@ -61,3 +61,10 @@ void FunctionalSimulator::writeBack(Instruction* instr) {
     // Stub: Write result back to register file, clear dirty bit
     (void)instr;
 }
+
+void FunctionalSimulator::clockPipelineRegisters() {
+    ifid_reg.clock();
+    idex_reg.clock();
+    exmem_reg.clock();
+    memwb_reg.clock();
+}

--- a/tests/functional_simulator/CMakeLists.txt
+++ b/tests/functional_simulator/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Create test executable for FunctionalSimulator tests
+set(TEST_NAME  functional_simulator_test)
+add_executable(${TEST_NAME} functional_simulator_tests.cpp)
+
+# Set C++ standard for the test (redundant but kept for clarity)
+target_compile_features(${TEST_NAME} PRIVATE cxx_std_17)
+
+# Link against Google Test and the main project library
+target_link_libraries(${TEST_NAME}
+    PRIVATE
+    gtest
+    gmock
+    gtest_main
+    mips_lite_lib
+)
+
+# Register with CTest using Google Test's discovery
+include(GoogleTest)
+gtest_discover_tests(${TEST_NAME})

--- a/tests/functional_simulator/functional_simulator_tests.cpp
+++ b/tests/functional_simulator/functional_simulator_tests.cpp
@@ -82,6 +82,33 @@ TEST_F(FunctionalSimulatorTest, ThrowsOnInvalidPipelineStageIndex) {
     EXPECT_THROW(sim->getPipelineStage(5), std::out_of_range);
 }
 
+TEST_F(FunctionalSimulatorTest, ClockPipelineRegistersUpdatesRegisterStates) {
+    // Create a known register file state for 2 different pipeline registers
+    RegisterFile if_id;
+    if_id.write(5, 42);  // write value 42 to R5
+
+    RegisterFile ex_mem;
+    ex_mem.write(8, 1000);  // write value 1000 to R8
+
+    // Confirm neither pipeline register has valid values prior to clocking
+    // in values from next
+    sim->ifid_reg.setNext(if_id);
+    EXPECT_FALSE(sim->ifid_reg.isValid());
+
+    sim->exmem_reg.setNext(ex_mem);
+    EXPECT_FALSE(sim->exmem_reg.isValid());
+
+    // Clock all pipeline registers
+    sim->clockPipelineRegisters();
+
+    // Check that pipelines registers have been updated
+    EXPECT_TRUE(sim->ifid_reg.isValid());
+    EXPECT_EQ(sim->ifid_reg.current().read(5), 42);
+
+    EXPECT_TRUE(sim->exmem_reg.isValid());
+    EXPECT_EQ(sim->exmem_reg.current().read(8), 1000);
+}
+
 /*
 // The following or something similar may be used to test individual methods
 // with mocked memory parser methods like readInstruction

--- a/tests/functional_simulator/functional_simulator_tests.cpp
+++ b/tests/functional_simulator/functional_simulator_tests.cpp
@@ -1,0 +1,93 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "functional_simulator.h"
+#include "memory_interface.h"
+#include "mips_instruction.h"
+#include "register_file.h"
+#include "stats.h"
+
+using ::testing::NiceMock;
+
+// ---------------------------
+// Mock classes
+// ---------------------------
+
+/**
+ * @brief Only MemoryParser is mocked for now.
+ *
+ * We use a mock for IMemoryParser to avoid file I/O during testing and to simulate
+ * custom memory access behavior (e.g., returning specific instruction values, simulating faults).
+ *
+ * The Stats and RegisterFile classes are not mocked because:
+ *  - They are small, fast, and side-effect-free.
+ *  - Their state is easy to inspect and assert directly (e.g., instruction counts, register
+ * values).
+ *
+ * We might choose to mock Stats or RegisterFile later if:
+ *  - We want to test interactions (e.g., how often `incrementStalls()` is called).
+ *  - Forwarding logic or hazard detection requires precise call tracking.
+ */
+
+class MockMemoryParser : public IMemoryParser {
+   public:
+    MOCK_METHOD(uint32_t, readInstruction, (uint32_t address), (override));
+    MOCK_METHOD(uint32_t, readMemory, (uint32_t address), (override));
+    MOCK_METHOD(void, writeMemory, (uint32_t address, uint32_t value), (override));
+};
+
+// ---------------------------
+// Test fixture
+// ---------------------------
+
+class FunctionalSimulatorTest : public ::testing::Test {
+   protected:
+    RegisterFile rf;
+    Stats stats;
+    NiceMock<MockMemoryParser> mem;
+    std::unique_ptr<FunctionalSimulator> sim;
+
+    void SetUp() override { sim = std::make_unique<FunctionalSimulator>(&rf, &stats, &mem); }
+};
+
+// ---------------------------
+// Test suite
+// ---------------------------
+
+TEST_F(FunctionalSimulatorTest, ConstructorInitializesMembers) {
+    EXPECT_EQ(sim->getPC(), 0);
+    EXPECT_EQ(sim->getStall(), 0);
+    EXPECT_FALSE(sim->isForwardingEnabled());
+
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_EQ(sim->getPipelineStage(i), nullptr);
+    }
+}
+
+TEST_F(FunctionalSimulatorTest, ConstructorEnablesForwarding) {
+    FunctionalSimulator forward_sim(&rf, &stats, &mem, true);
+    EXPECT_TRUE(forward_sim.isForwardingEnabled());
+}
+
+TEST_F(FunctionalSimulatorTest, SettersUpdateInternalState) {
+    sim->setPC(0x00400020);
+    sim->setStall(3);
+
+    EXPECT_EQ(sim->getPC(), 0x00400020);
+    EXPECT_EQ(sim->getStall(), 3);
+}
+
+TEST_F(FunctionalSimulatorTest, ThrowsOnInvalidPipelineStageIndex) {
+    EXPECT_THROW(sim->getPipelineStage(-1), std::out_of_range);
+    EXPECT_THROW(sim->getPipelineStage(5), std::out_of_range);
+}
+
+/*
+// The following or something similar may be used to test individual methods
+// with mocked memory parser methods like readInstruction
+// Requires addition of `using ::testing::Return;` above
+TEST_F(FunctionalSimulatorTest, FetchReadsInstructionFromMemory) {
+    EXPECT_CALL(mem, readInstruction(0)).Times(1).WillOnce(Return(0x040103E8));
+    sim->instructionFetch();  // Assuming it internally calls readInstruction
+}
+*/

--- a/tests/libs/CMakeLists.txt
+++ b/tests/libs/CMakeLists.txt
@@ -7,7 +7,7 @@ target_compile_features(test_stats PRIVATE cxx_std_17)
 target_include_directories(test_stats PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 # Link against Google Test
-target_link_libraries(test_stats PRIVATE stats gtest gtest_main)
+target_link_libraries(test_stats PRIVATE mips_lite_lib gtest gtest_main)
 
 # Register with CTest using Google Test's discovery
 include(GoogleTest)


### PR DESCRIPTION
Adds a functional simulator class with the basic members that are presumed to be needed at this point, as well as tests for initialization and member setter methods. Test file includes a basic example to show generally how we might begin testing more complex functionality like the instruction methods.

~~**Note:** We will need to add pipeline registers from #17 to this class eventually.~~ Added pipeline registers in c36675497989a6f6aeafd4a116468d8b6ed9f01a