### PR TITLE
Removing pipeline register type and consolidating to array of struct …

### DIFF
--- a/include/functional_simulator.h
+++ b/include/functional_simulator.h
@@ -27,7 +27,6 @@ struct PipelineStageData {
     uint32_t alu_result;   ///< Result of ALU operation or effective address
     uint32_t memory_data;  ///< Data read from memory (if applicable)
     std::optional<uint8_t> dest_reg;  ///< Destination register (if any)
-    bool branch_taken;                ///< Whether a branch is taken
     uint32_t branch_target;           ///< Target address for branch/jump
 
     // Constructor to initialize with default values
@@ -39,7 +38,6 @@ struct PipelineStageData {
           alu_result(0),
           memory_data(0),
           dest_reg(std::nullopt),
-          branch_taken(false),
           branch_target(0) {}
 
     // Constructor with instruction
@@ -51,7 +49,6 @@ struct PipelineStageData {
           alu_result(0),
           memory_data(0),
           dest_reg(std::nullopt),
-          branch_taken(false),
           branch_target(0) {}
 
     // Check if stage is a bubble (no instruction)
@@ -98,6 +95,8 @@ class FunctionalSimulator {
      * @return Number of remaining stall cycles.
      */
     uint8_t getStall() const;
+
+    static constexpr int getNumStages() { return NUM_STAGES; }
 
     /**
      * @brief Get the pipeline stage data at the given pipeline stage.
@@ -194,18 +193,19 @@ class FunctionalSimulator {
         EXECUTE = 2,
         MEMORY = 3,
         WRITEBACK = 4,
-        NUM_STAGES = 5
     };
 
    private:
     /// Program Counter
+    static constexpr int NUM_STAGES = 5;
     uint32_t pc;
+    bool branch_taken;
 
     /// General purpose registers
     RegisterFile* register_file;
 
     /// 5-stage pipeline array
-    std::array<std::unique_ptr<PipelineStageData>, PipelineStage::NUM_STAGES> pipeline;
+    std::array<std::unique_ptr<PipelineStageData>, NUM_STAGES> pipeline;
 
     /// Stats instance to track runtime metrics
     Stats* stats;

--- a/src/functional_simulator.cpp
+++ b/src/functional_simulator.cpp
@@ -63,6 +63,7 @@ void FunctionalSimulator::writeBack() {
 }
 
 void FunctionalSimulator::advancePipeline() {
+    // TODO: Might need to add more checks here
     // Release writeback stage
     pipeline[PipelineStage::WRITEBACK].reset();  // Smart pointer will delete the object
 
@@ -80,7 +81,7 @@ void FunctionalSimulator::advancePipeline() {
 }
 
 void FunctionalSimulator::cycle() {
-    // Execute stages in reverse order since each stage depends on the previous one
+    // Execute stages in reverse order since writeback should happen first
     // TODO: Might need to add other control logic here
     writeBack();
     memory();

--- a/src/functional_simulator.cpp
+++ b/src/functional_simulator.cpp
@@ -1,5 +1,8 @@
 #include "functional_simulator.h"
 
+#include <cstddef>
+#include <cstdint>
+
 #include "memory_interface.h"
 #include "mips_instruction.h"
 #include "register_file.h"
@@ -12,11 +15,7 @@ FunctionalSimulator::FunctionalSimulator(RegisterFile* rf, Stats* st, IMemoryPar
       stats(st),
       memory_parser(mem),
       forward(enable_forwarding),
-      stall(0) {
-    for (auto& stage : pipeline) {
-        stage = nullptr;
-    }
-}
+      stall(0) {}
 
 uint32_t FunctionalSimulator::getPC() const { return pc; }
 
@@ -24,47 +23,128 @@ bool FunctionalSimulator::isForwardingEnabled() const { return forward; }
 
 uint8_t FunctionalSimulator::getStall() const { return stall; }
 
-Instruction* FunctionalSimulator::getPipelineStage(int stage) const {
-    if (stage < 0 || stage >= 5) {
-        throw std::out_of_range("Pipeline stage index out of range");
-    }
-    return pipeline[stage];
-}
-
 void FunctionalSimulator::setPC(uint32_t new_pc) { pc = new_pc; }
 
 void FunctionalSimulator::setStall(uint8_t cycles) { stall = cycles; }
 
-void FunctionalSimulator::instructionFetch() {
-    // Stub: Should first check stall count to determine if a null pointer should be inserted
-    // Otherwise, fetch instruction at PC using memory_parser and insert into pipeline[0],
-    // then update PC by word size
+const PipelineStageData* FunctionalSimulator::getPipelineStage(int stage) const {
+    if (stage < 0 || stage >= PipelineStage::NUM_STAGES) {
+        throw std::out_of_range("Pipeline stage index out of range");
+    }
+    return pipeline[stage].get();  // Use .get() to return the raw pointer
 }
 
-void FunctionalSimulator::instructionDecode(Instruction* instr) {
+bool FunctionalSimulator::isStageEmpty(int stage) const {
+    if (stage < 0 || stage >= PipelineStage::NUM_STAGES) {
+        throw std::out_of_range("Pipeline stage index out of range");
+    }
+    return pipeline[stage] == nullptr;
+}
+
+void FunctionalSimulator::instructionFetch() {
+    if (stall > 0) {
+        return;  // Skip fetch if stall is active
+    }
+}
+
+void FunctionalSimulator::instructionDecode() {
     // Stub: Decode the instruction (parse operands, maybe identify hazards)
     // Set dirty bit on registers which will be written back to later
-    (void)instr;  // Silence unused parameter warning
 }
 
-void FunctionalSimulator::execute(Instruction* instr) {
+void FunctionalSimulator::execute() {
     // Stub: Perform ALU operation specified or calculate branch effective address
-    (void)instr;
 }
 
-void FunctionalSimulator::memory(Instruction* instr) {
+void FunctionalSimulator::memory() {
     // Stub: Access memory if needed (load or store only)
-    (void)instr;
 }
 
-void FunctionalSimulator::writeBack(Instruction* instr) {
+void FunctionalSimulator::writeBack() {
     // Stub: Write result back to register file, clear dirty bit
-    (void)instr;
 }
 
-void FunctionalSimulator::clockPipelineRegisters() {
-    ifid_reg.clock();
-    idex_reg.clock();
-    exmem_reg.clock();
-    memwb_reg.clock();
+void FunctionalSimulator::advancePipeline() {
+    // Release writeback stage
+    pipeline[PipelineStage::WRITEBACK].reset();  // Smart pointer will delete the object
+
+    // Shift instructions forward in the pipeline (from higher to lower to avoid overwriting)
+    for (int i = PipelineStage::WRITEBACK; i > PipelineStage::FETCH; i--) {
+        pipeline[i] = std::move(pipeline[i - 1]);
+    }
+    // Note because of std::move Fetch stage is now empty
+
+    // Decrement stall counter if active
+    if (stall > 0) {
+        stall--;
+    }
+    // TODO: Maybe increase tick counter here for stats
+}
+
+void FunctionalSimulator::cycle() {
+    // Execute stages in reverse order since each stage depends on the previous one
+    // TODO: Might need to add other control logic here
+    writeBack();
+    memory();
+    execute();
+    instructionDecode();
+    instructionFetch();
+
+    // Advance pipeline
+    advancePipeline();
+}
+
+bool FunctionalSimulator::detectHazards() {
+    // If forwarding is enabled, fewer stalls are needed
+    if (forward || isStageEmpty(PipelineStage::DECODE)) {
+        // TODO: Implement hazard detection with forwarding
+        return false;
+    } else {
+        // Simple hazard detection for no forwarding:
+        // Check if instruction in decode stage depends on result of instruction in execute or
+        // memory stage
+        return false;
+    }
+    return false;
+}
+
+bool FunctionalSimulator::isRegisterWriteInstruction(const Instruction* instr) const {
+    if (instr == nullptr) {
+        return false;
+    }
+
+    uint8_t opcode = instr->getOpcode();
+
+    // R-type instructions always write to a register
+    if (instr->getInstructionType() == mips_lite::InstructionType::R_TYPE) {
+        return true;
+    }
+
+    // Only some I-type instructions write to a register
+    return opcode == mips_lite::opcode::ADDI || opcode == mips_lite::opcode::SUBI ||
+           opcode == mips_lite::opcode::MULI || opcode == mips_lite::opcode::ORI ||
+           opcode == mips_lite::opcode::ANDI || opcode == mips_lite::opcode::XORI ||
+           opcode == mips_lite::opcode::LDW;
+}
+
+std::optional<uint8_t> FunctionalSimulator::getDestinationRegister(const Instruction* instr) const {
+    if (instr == nullptr || !isRegisterWriteInstruction(instr)) {
+        return std::nullopt;
+    }
+
+    // R-type instructions write to rd
+    if (instr->getInstructionType() == mips_lite::InstructionType::R_TYPE) {
+        return instr->getRd();
+    }
+
+    // I-type instructions that write to a register use rt as destination
+    return instr->getRt();
+}
+
+uint32_t FunctionalSimulator::getForwardedValue(int stage, uint8_t reg_num) {
+    (void)stage;
+    (void)reg_num;
+    // TODO: Implement forwarding logic
+    // Check if the register is being written in the pipeline stages
+    return 0;
 }

--- a/src/functional_simulator.cpp
+++ b/src/functional_simulator.cpp
@@ -28,23 +28,21 @@ void FunctionalSimulator::setPC(uint32_t new_pc) { pc = new_pc; }
 void FunctionalSimulator::setStall(uint8_t cycles) { stall = cycles; }
 
 const PipelineStageData* FunctionalSimulator::getPipelineStage(int stage) const {
-    if (stage < 0 || stage >= PipelineStage::NUM_STAGES) {
+    if (stage < 0 || stage >= NUM_STAGES) {
         throw std::out_of_range("Pipeline stage index out of range");
     }
     return pipeline[stage].get();  // Use .get() to return the raw pointer
 }
 
 bool FunctionalSimulator::isStageEmpty(int stage) const {
-    if (stage < 0 || stage >= PipelineStage::NUM_STAGES) {
+    if (stage < 0 || stage >= NUM_STAGES) {
         throw std::out_of_range("Pipeline stage index out of range");
     }
     return pipeline[stage] == nullptr;
 }
 
 void FunctionalSimulator::instructionFetch() {
-    if (stall > 0) {
-        return;  // Skip fetch if stall is active
-    }
+    // Stub: TODO
 }
 
 void FunctionalSimulator::instructionDecode() {

--- a/tests/functional_simulator/functional_simulator_tests.cpp
+++ b/tests/functional_simulator/functional_simulator_tests.cpp
@@ -77,7 +77,7 @@ TEST_F(FunctionalSimulatorTest, SettersAndGetters) {
 
 // Test pipeline stages initially empty
 TEST_F(FunctionalSimulatorTest, PipelineInitiallyEmpty) {
-    for (int i = 0; i < FunctionalSimulator::PipelineStage::NUM_STAGES; ++i) {
+    for (int i = 0; i < FunctionalSimulator::getNumStages(); ++i) {
         EXPECT_TRUE(sim->isStageEmpty(i));
         EXPECT_EQ(sim->getPipelineStage(i), nullptr);
     }
@@ -109,7 +109,16 @@ TEST_F(FunctionalSimulatorTest, StallDecrement) {
 
 // Test that getPipelineStage returns nullptr for empty stages
 TEST_F(FunctionalSimulatorTest, GetPipelineStage) {
-    for (int i = 0; i < FunctionalSimulator::PipelineStage::NUM_STAGES; ++i) {
+    for (int i = 0; i < FunctionalSimulator::getNumStages(); ++i) {
         EXPECT_EQ(sim->getPipelineStage(i), nullptr);
     }
 }
+
+/*
+// The following or something similar may be used to test individual methods
+// with mocked memory parser methods like readInstruction
+// Requires addition of `using ::testing::Return;` above
+TEST_F(FunctionalSimulatorTest, FetchReadsInstructionFromMemory) {
+    EXPECT_CALL(mem, readInstruction(0)).Times(1).WillOnce(Return(0x040103E8));
+    sim->instructionFetch();  // Assuming it internally calls readInstruction
+*/

--- a/tests/functional_simulator/functional_simulator_tests.cpp
+++ b/tests/functional_simulator/functional_simulator_tests.cpp
@@ -54,22 +54,20 @@ class FunctionalSimulatorTest : public ::testing::Test {
 // Test suite
 // ---------------------------
 
-TEST_F(FunctionalSimulatorTest, ConstructorInitializesMembers) {
+TEST_F(FunctionalSimulatorTest, Initialization) {
     EXPECT_EQ(sim->getPC(), 0);
     EXPECT_EQ(sim->getStall(), 0);
     EXPECT_FALSE(sim->isForwardingEnabled());
-
-    for (int i = 0; i < 5; ++i) {
-        EXPECT_EQ(sim->getPipelineStage(i), nullptr);
-    }
 }
 
-TEST_F(FunctionalSimulatorTest, ConstructorEnablesForwarding) {
+// Test forwarding flag
+TEST_F(FunctionalSimulatorTest, ForwardingFlag) {
     FunctionalSimulator forward_sim(&rf, &stats, &mem, true);
     EXPECT_TRUE(forward_sim.isForwardingEnabled());
 }
 
-TEST_F(FunctionalSimulatorTest, SettersUpdateInternalState) {
+// Test setters and getters
+TEST_F(FunctionalSimulatorTest, SettersAndGetters) {
     sim->setPC(0x00400020);
     sim->setStall(3);
 
@@ -77,44 +75,41 @@ TEST_F(FunctionalSimulatorTest, SettersUpdateInternalState) {
     EXPECT_EQ(sim->getStall(), 3);
 }
 
-TEST_F(FunctionalSimulatorTest, ThrowsOnInvalidPipelineStageIndex) {
+// Test pipeline stages initially empty
+TEST_F(FunctionalSimulatorTest, PipelineInitiallyEmpty) {
+    for (int i = 0; i < FunctionalSimulator::PipelineStage::NUM_STAGES; ++i) {
+        EXPECT_TRUE(sim->isStageEmpty(i));
+        EXPECT_EQ(sim->getPipelineStage(i), nullptr);
+    }
+}
+
+// Test bounds checking
+TEST_F(FunctionalSimulatorTest, BoundsChecking) {
+    EXPECT_THROW(sim->isStageEmpty(-1), std::out_of_range);
+    EXPECT_THROW(sim->isStageEmpty(5), std::out_of_range);
     EXPECT_THROW(sim->getPipelineStage(-1), std::out_of_range);
     EXPECT_THROW(sim->getPipelineStage(5), std::out_of_range);
 }
 
-TEST_F(FunctionalSimulatorTest, ClockPipelineRegistersUpdatesRegisterStates) {
-    // Create pipeline data with result and destination register
-    PipelineData<uint32_t> idex_data = {42, 5};     // Intermediate value 42 targeting R5
-    PipelineData<uint32_t> exmem_data = {1000, 8};  // Intermediate value 1000 targeting R8
+// Test stall counter decrements
+TEST_F(FunctionalSimulatorTest, StallDecrement) {
+    sim->setStall(2);
+    EXPECT_EQ(sim->getStall(), 2);
 
-    // Load as next values (not yet clocked)
-    sim->idex_reg.setNext(idex_data);
-    EXPECT_FALSE(sim->idex_reg.isValid());
+    sim->advancePipeline();
+    EXPECT_EQ(sim->getStall(), 1);
 
-    sim->exmem_reg.setNext(exmem_data);
-    EXPECT_FALSE(sim->exmem_reg.isValid());
+    sim->advancePipeline();
+    EXPECT_EQ(sim->getStall(), 0);
 
-    // Clock the pipeline
-    sim->clockPipelineRegisters();
-
-    // Verify contents now valid and accessible
-    EXPECT_TRUE(sim->idex_reg.isValid());
-    EXPECT_EQ(sim->idex_reg.current().result, 42);
-    ASSERT_TRUE(sim->idex_reg.current().wb_reg.has_value());
-    EXPECT_EQ(sim->idex_reg.current().wb_reg.value(), 5);
-
-    EXPECT_TRUE(sim->exmem_reg.isValid());
-    EXPECT_EQ(sim->exmem_reg.current().result, 1000);
-    ASSERT_TRUE(sim->exmem_reg.current().wb_reg.has_value());
-    EXPECT_EQ(sim->exmem_reg.current().wb_reg.value(), 8);
+    // Should not go below zero
+    sim->advancePipeline();
+    EXPECT_EQ(sim->getStall(), 0);
 }
 
-/*
-// The following or something similar may be used to test individual methods
-// with mocked memory parser methods like readInstruction
-// Requires addition of `using ::testing::Return;` above
-TEST_F(FunctionalSimulatorTest, FetchReadsInstructionFromMemory) {
-    EXPECT_CALL(mem, readInstruction(0)).Times(1).WillOnce(Return(0x040103E8));
-    sim->instructionFetch();  // Assuming it internally calls readInstruction
+// Test that getPipelineStage returns nullptr for empty stages
+TEST_F(FunctionalSimulatorTest, GetPipelineStage) {
+    for (int i = 0; i < FunctionalSimulator::PipelineStage::NUM_STAGES; ++i) {
+        EXPECT_EQ(sim->getPipelineStage(i), nullptr);
+    }
 }
-*/


### PR DESCRIPTION
@nkanderson  Here are the changes we discussed during our white board session. I decided to go with smart pointers in the pipeline array to, hopefully, make our lives easier and prevent memory issues. Let me know if you have questions. 