### PR TITLE
Add memory method

### DIFF
--- a/src/functional_simulator.cpp
+++ b/src/functional_simulator.cpp
@@ -1,9 +1,8 @@
 #include "functional_simulator.h"
 
-#include <cstdint>
-
 #include <sys/types.h>
 
+#include <cstdint>
 #include <optional>
 
 #include "memory_interface.h"
@@ -51,7 +50,7 @@ void FunctionalSimulator::instructionFetch() {
 
 void FunctionalSimulator::instructionDecode() {
     // Operation: Decode instruction and access register file to read the register sources
-    
+
     PipelineStageData* id_data = pipeline[PipelineStage::DECODE].get();
 
     if (id_data == nullptr || stall > 0) {
@@ -61,23 +60,22 @@ void FunctionalSimulator::instructionDecode() {
 
     uint8_t rs = id_data->instruction->getRs();
     uint8_t rt = id_data->instruction->getRt();
-    
+
     id_data->rs_value = readRegisterValue(rs);
 
     // Determine register Destination & optional second source register
-    if(id_data->instruction->hasRd()) {
+    if (id_data->instruction->hasRd()) {
         id_data->dest_reg = id_data->instruction->getRd();
-        //R-type instruction has two source registers, get second source register
+        // R-type instruction has two source registers, get second source register
         id_data->rt_value = readRegisterValue(rt);
-    }
-    else if(!id_data->instruction->hasRd() && isRegisterWriteInstruction(id_data->instruction.get())) {
-        // Destination register is rt 
+    } else if (!id_data->instruction->hasRd() &&
+               isRegisterWriteInstruction(id_data->instruction.get())) {
+        // Destination register is rt
         id_data->dest_reg = id_data->instruction->getRt();
-    }
-    else {
+    } else {
         // No destination register
         id_data->dest_reg = std::nullopt;
-        if(id_data->instruction->getOpcode() == mips_lite::opcode::BEQ) {
+        if (id_data->instruction->getOpcode() == mips_lite::opcode::BEQ) {
             // BEQ has two source registers
             id_data->rt_value = readRegisterValue(rt);
         }
@@ -85,11 +83,11 @@ void FunctionalSimulator::instructionDecode() {
 }
 
 void FunctionalSimulator::execute() {
-    if(isStageEmpty(PipelineStage::EXECUTE)) {
+    if (isStageEmpty(PipelineStage::EXECUTE)) {
         // No instruction to execute
         return;
     }
-    PipelineStageData* ex_data = pipeline[PipelineStage::EXECUTE].get(); 
+    PipelineStageData* ex_data = pipeline[PipelineStage::EXECUTE].get();
 
     switch (ex_data->instruction->getOpcode()) {
         // Arithmetic Operations
@@ -98,21 +96,24 @@ void FunctionalSimulator::execute() {
             ex_data->alu_result = ex_data->getRsValueSigned() + ex_data->getRtValueSigned();
             break;
         case mips_lite::opcode::ADDI:
-            ex_data->alu_result = ex_data->getRsValueSigned() + ex_data->instruction->getImmediate();
+            ex_data->alu_result =
+                ex_data->getRsValueSigned() + ex_data->instruction->getImmediate();
             break;
 
         case mips_lite::opcode::SUB:
             ex_data->alu_result = ex_data->getRsValueSigned() - ex_data->getRtValueSigned();
             break;
         case mips_lite::opcode::SUBI:
-            ex_data->alu_result = ex_data->getRsValueSigned() - ex_data->instruction->getImmediate();
+            ex_data->alu_result =
+                ex_data->getRsValueSigned() - ex_data->instruction->getImmediate();
             break;
 
         case mips_lite::opcode::MUL:
             ex_data->alu_result = ex_data->getRsValueSigned() * ex_data->getRtValueSigned();
             break;
         case mips_lite::opcode::MULI:
-            ex_data->alu_result = ex_data->getRsValueSigned() * ex_data->instruction->getImmediate();
+            ex_data->alu_result =
+                ex_data->getRsValueSigned() * ex_data->instruction->getImmediate();
             break;
 
         // Logical Operations
@@ -142,11 +143,13 @@ void FunctionalSimulator::execute() {
         // Effective Address Calculation is signed
         case mips_lite::opcode::LDW:
             // Load word - calculate effective address
-            ex_data->alu_result = ex_data->getRsValueSigned() + ex_data->instruction->getImmediate();
+            ex_data->alu_result =
+                ex_data->getRsValueSigned() + ex_data->instruction->getImmediate();
             break;
 
         case mips_lite::opcode::STW:
-            ex_data->alu_result = ex_data->getRsValueSigned() + ex_data->instruction->getImmediate();
+            ex_data->alu_result =
+                ex_data->getRsValueSigned() + ex_data->instruction->getImmediate();
             break;
 
         // Control Flow Ops
@@ -154,29 +157,31 @@ void FunctionalSimulator::execute() {
             if (ex_data->rs_value == 0) {
                 ex_data->alu_result = ex_data->pc + (ex_data->instruction->getImmediate() * 4);
                 branch_taken = true;  // Indicate that a branch was taken
-                                      // TODO: Controller will need to clear this flag after the branch is taken
+                                      // TODO: Controller will need to clear this flag after the
+                                      // branch is taken
                 break;
             }
-            branch_taken = false;  // No branch taken
+            branch_taken = false;               // No branch taken
             ex_data->alu_result = ex_data->pc;  // No change (PC should be updated in fetch stage)
             break;
 
         case mips_lite::opcode::BEQ:
             if (ex_data->rs_value == ex_data->rt_value) {
                 // Branch if equal - calculate target address
-                
+
                 ex_data->alu_result = ex_data->pc + (ex_data->instruction->getImmediate() * 4);
                 branch_taken = true;  // Indicate that a branch was taken
             } else {
                 // No branch, PC will be updated normally
                 branch_taken = false;  // No branch taken
-                ex_data->alu_result = ex_data->pc;  // No change (PC should be updated in fetch stage)
+                ex_data->alu_result =
+                    ex_data->pc;  // No change (PC should be updated in fetch stage)
             }
             break;
 
         case mips_lite::opcode::JR:
             // Jump register - use the value in Rs as the new PC
-            ex_data->alu_result = ex_data->rs_value;  // Set PC to value in Rs 
+            ex_data->alu_result = ex_data->rs_value;  // Set PC to value in Rs
             branch_taken = true;
             break;
 
@@ -343,22 +348,24 @@ bool FunctionalSimulator::isRegisterWriteInstruction(const Instruction* instr) c
 }
 
 uint32_t FunctionalSimulator::readRegisterValue(uint8_t reg_num) {
-    
     if (reg_num == 0) {
         return 0;  // $0 register always returns 0
-    }               // And never has hazards
-    if(stall > 0) {
-        throw std::runtime_error("Stall detected in ID stage but wasn't properly handled by control logic. Should never attempt to read during a stall");
+    }              // And never has hazards
+    if (stall > 0) {
+        throw std::runtime_error(
+            "Stall detected in ID stage but wasn't properly handled by control logic. Should never "
+            "attempt to read during a stall");
     }
     // Check EXE stage for hazards
-    if(!isStageEmpty(PipelineStage::EXECUTE) && pipeline[PipelineStage::EXECUTE]->dest_reg.value() == reg_num) {
+    if (!isStageEmpty(PipelineStage::EXECUTE) &&
+        pipeline[PipelineStage::EXECUTE]->dest_reg.value() == reg_num) {
         return pipeline[PipelineStage::EXECUTE]->alu_result;
     }
     // Check MEM stage for hazards
-    if(!isStageEmpty(PipelineStage::MEMORY) && pipeline[PipelineStage::MEMORY]->dest_reg.value() == reg_num) {
+    if (!isStageEmpty(PipelineStage::MEMORY) &&
+        pipeline[PipelineStage::MEMORY]->dest_reg.value() == reg_num) {
         return pipeline[PipelineStage::MEMORY]->alu_result;
-    }
-    else {
+    } else {
         return register_file->read(reg_num);
     }
 }

--- a/tests/functional_simulator/functional_simulator_tests.cpp
+++ b/tests/functional_simulator/functional_simulator_tests.cpp
@@ -168,6 +168,89 @@ TEST_F(FunctionalSimulatorTest, WriteBackEmptyDestRegReturns) {
     EXPECT_EQ(modified_regs.size(), 0);
 }
 
+/**
+ * @test MemoryStageLoadsDataFromMemory
+ * @brief Verifies that a load instruction causes the simulator to read from memory
+ * and stores the result in the pipeline's memory_data field.
+ */
+TEST_F(FunctionalSimulatorTest, MemoryStageLoadsDataFromMemory) {
+    constexpr uint32_t addr = 0x1000;
+    constexpr uint32_t loaded_value = 0x1234ABCD;
+
+    EXPECT_CALL(mem, readMemory(addr)).Times(1).WillOnce(::testing::Return(loaded_value));
+
+    auto data = std::make_unique<PipelineStageData>();
+    data->alu_result = addr;
+    data->instruction = std::make_unique<Instruction>((mips_lite::opcode::LDW << 26));
+
+    sim->getPipeline()[FunctionalSimulator::MEMORY] = std::move(data);
+
+    sim->memory();
+
+    auto* result = sim->getPipelineStage(FunctionalSimulator::MEMORY);
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(result->memory_data, loaded_value);
+}
+
+/**
+ * @test MemoryStageStoresDataToMemory
+ * @brief Verifies that a store instruction writes the correct value to memory and
+ * logs the memory address in the stats tracker.
+ */
+TEST_F(FunctionalSimulatorTest, MemoryStageStoresDataToMemory) {
+    constexpr uint32_t addr = 0x2000;
+    constexpr uint32_t store_value = 0xABCD5678;
+
+    EXPECT_CALL(mem, writeMemory(addr, store_value)).Times(1);
+
+    auto data = std::make_unique<PipelineStageData>();
+    data->alu_result = addr;
+    data->rt_value = store_value;
+    data->instruction = std::make_unique<Instruction>((mips_lite::opcode::STW << 26));
+
+    sim->getPipeline()[FunctionalSimulator::MEMORY] = std::move(data);
+
+    sim->memory();
+
+    const auto& modified_addrs = stats.getMemoryAddresses();
+    EXPECT_EQ(modified_addrs.size(), 1);
+    EXPECT_TRUE(modified_addrs.count(addr));
+}
+
+/**
+ * @test MemoryStageIgnoresNonMemoryInstructions
+ * @brief Ensures that the memory stage does not perform any memory access
+ * for non-memory instructions like MUL.
+ */
+TEST_F(FunctionalSimulatorTest, MemoryStageIgnoresNonMemoryInstructions) {
+    constexpr uint32_t mult_result = 0x3000;
+
+    // These should NOT be called
+    EXPECT_CALL(mem, readMemory).Times(0);
+    EXPECT_CALL(mem, writeMemory).Times(0);
+
+    auto data = std::make_unique<PipelineStageData>();
+    // This would be treated as an address in a load / store, but is a multiply result for MULT
+    data->alu_result = mult_result;
+    // Should remain unchanged from the initialized value of 0x0
+    data->memory_data = 0x0;
+    data->instruction = std::make_unique<Instruction>((mips_lite::opcode::MUL << 26));
+
+    sim->getPipeline()[FunctionalSimulator::MEMORY] = std::move(data);
+
+    sim->memory();
+
+    const auto* result = sim->getPipelineStage(FunctionalSimulator::MEMORY);
+    ASSERT_NE(result, nullptr);
+
+    // memory_data should not be changed
+    EXPECT_EQ(result->memory_data, 0x0);
+
+    // No memory addresses should be added to stats
+    const auto& modified_addrs = stats.getMemoryAddresses();
+    EXPECT_EQ(modified_addrs.size(), 0);
+}
+
 /*
 // The following or something similar may be used to test individual methods
 // with mocked memory parser methods like readInstruction


### PR DESCRIPTION
Adds `memory` method for the functional simulator, and updates the `writeBack` method to use `memory_data` instead of `alu_result` when handling a load instruction.

FYI, 13279eeb1b118c355beafed76fa3a283e22d0262 is an automated formatting commit, so skip that one if you just want to see the functional changes associated with this PR.