### PR TITLE
Fs cycle control logic

### DIFF
--- a/include/functional_simulator.h
+++ b/include/functional_simulator.h
@@ -92,7 +92,7 @@ class FunctionalSimulator {
      */
     bool isForwardingEnabled() const;
 
-    bool isProgramFinished() const { return program_finished; }
+    bool isProgramFinished() { return checkProgramCompletion(); }
 
     /**
      * @brief Get the stall signal.
@@ -215,11 +215,10 @@ class FunctionalSimulator {
     IMemoryParser* memory_parser;
 
     // Control signals
-    bool branch_taken = false;      // EXE stage sets this to true if a branch is taken
-    bool forward = false;           // Forwarding enabled or not during construction
-    bool halt_pipeline = false;     // Set to true when fetch stage encounters a halt instruction
-    bool stall = false;             // Set to true when a hazard is detected
-    bool program_finished = false;  // Set to true when the program has finished executing
+    bool branch_taken = false;   // EXE stage sets this to true if a branch is taken
+    bool forward = false;        // Forwarding enabled or not during construction
+    bool halt_pipeline = false;  // Set to true when fetch stage encounters a halt instruction
+    bool stall = false;          // Set to true when a hazard is detected
 
     /**
      * @brief Helper method to check if an instruction writes to a register.
@@ -247,6 +246,11 @@ class FunctionalSimulator {
      */
     bool detectStalls(void);
 
+    // Hazard helper methods
+    bool causesHazard(uint8_t reg_num, uint8_t dest_reg) const;
+    bool checkExecuteStageForHazard(uint8_t rs, uint8_t rt, bool needs_rt) const;
+    bool checkMemoryStageForHazard(uint8_t rs, uint8_t rt, bool needs_rt) const;
+
     // determines if the instruction needs the Rt register value as a source operand
     bool needsRtValue(const Instruction* instr) const;
 
@@ -254,7 +258,7 @@ class FunctionalSimulator {
      * @brief Check if the program has finished executing. If so it will set
      * program_finished to true
      */
-    void checkProgramCompletion(void);
+    bool checkProgramCompletion(void);
 
 #ifdef UNIT_TEST
     // Allow functional simulator tests access to private class member pipeline

--- a/include/functional_simulator.h
+++ b/include/functional_simulator.h
@@ -246,6 +246,20 @@ class FunctionalSimulator {
      */
     uint32_t readRegisterValue(uint8_t reg_num);
 
+    /* @brief Detects hazards in the pipeline and returns the number of stall cycles needed.
+ * 
+ * This method checks for data hazards between the stages of the pipeline. If a hazard is detected,
+ * it returns the number of stall cycles required to resolve it. If no hazards are detected, it
+ * returns 0.
+ *
+ * @return Number of stall cycles needed to resolve hazards, or 0 if no hazards are detected.
+ */
+    int detectStalls(void);
+    
+    bool needsRtValue(const Instruction* instr) const;
+
+
+
 #ifdef UNIT_TEST
      // Allow functional simulator tests access to private class member pipeline
    public:

--- a/include/functional_simulator.h
+++ b/include/functional_simulator.h
@@ -78,7 +78,6 @@ class FunctionalSimulator {
     FunctionalSimulator(RegisterFile* rf, Stats* st, IMemoryParser* mem,
                         bool enable_forwarding = false);
 
-
     // Getter methods
 
     /**
@@ -201,8 +200,7 @@ class FunctionalSimulator {
    private:
     /// Program Counter
     static constexpr int NUM_STAGES = 5;
-    uint32_t pc;
-    bool branch_taken;
+    uint32_t pc = 0;
 
     /// General purpose registers
     RegisterFile* register_file;
@@ -216,16 +214,12 @@ class FunctionalSimulator {
     /// Serves as the simulator memory
     IMemoryParser* memory_parser;
 
-    /// Whether or not data forwarding is enabled
-    bool forward;
-
-    /// Add flag for halt instruction
-    bool halt_pipeline = false;
-
-    /// Stall signal
-    bool stall = false;
-
-    bool program_finished = false; 
+    // Control signals
+    bool branch_taken = false;      // EXE stage sets this to true if a branch is taken
+    bool forward = false;           // Forwarding enabled or not during construction
+    bool halt_pipeline = false;     // Set to true when fetch stage encounters a halt instruction
+    bool stall = false;             // Set to true when a hazard is detected
+    bool program_finished = false;  // Set to true when the program has finished executing
 
     /**
      * @brief Helper method to check if an instruction writes to a register.
@@ -234,42 +228,37 @@ class FunctionalSimulator {
      */
     bool isRegisterWriteInstruction(const Instruction* instr) const;
 
-
     /**
      * @brief Helper method to get the value of a register.
      * @param reg_num Register number to read. Handles forwarding if needed. Note that this
-     * function should only be called when the pipeline is not stalled. If stalled we shouldn't be 
+     * function should only be called when the pipeline is not stalled. If stalled we shouldn't be
      * reading any registers.
      * @return Value of the register.
      */
     uint32_t readRegisterValue(uint8_t reg_num);
 
     /* @brief Detects hazards in the pipeline and returns the number of stall cycles needed.
-    * 
-    * This method checks for data hazards between the stages of the pipeline. If a hazard is detected,
-    * it returns the number of stall cycles required to resolve it. If no hazards are detected, it
-    * returns 0.
-    *
-    * @return Number of stall cycles needed to resolve hazards, or 0 if no hazards are detected.
-    */
+     *
+     * This method checks for data hazards between the stages of the pipeline. If a hazard is
+     * detected, it returns the number of stall cycles required to resolve it. If no hazards are
+     * detected, it returns 0.
+     *
+     * @return Number of stall cycles needed to resolve hazards, or 0 if no hazards are detected.
+     */
     bool detectStalls(void);
 
     // determines if the instruction needs the Rt register value as a source operand
     bool needsRtValue(const Instruction* instr) const;
 
     /** check for program completion
-     * @brief Check if the program has finished executing. If so it will set 
-     * program_finished to true 
+     * @brief Check if the program has finished executing. If so it will set
+     * program_finished to true
      */
     void checkProgramCompletion(void);
 
-
-
-
 #ifdef UNIT_TEST
-     // Allow functional simulator tests access to private class member pipeline
+    // Allow functional simulator tests access to private class member pipeline
    public:
     std::array<std::unique_ptr<PipelineStageData>, NUM_STAGES>& getPipeline() { return pipeline; }
 #endif
-
 };

--- a/include/functional_simulator.h
+++ b/include/functional_simulator.h
@@ -93,11 +93,13 @@ class FunctionalSimulator {
      */
     bool isForwardingEnabled() const;
 
+    bool isProgramFinished() const { return program_finished; }
+
     /**
-     * @brief Get the current stall count.
-     * @return Number of remaining stall cycles.
+     * @brief Get the stall signal.
+     * @return True if the pipeline is stalled, false otherwise.
      */
-    uint8_t getStall() const;
+    bool getStall() const;
 
     bool isHalted() const { return halt_pipeline; }
 
@@ -120,12 +122,6 @@ class FunctionalSimulator {
      * @param new_pc New value for the PC.
      */
     void setPC(uint32_t new_pc);
-
-    /**
-     * @brief Set the number of stall cycles.
-     * @param cycles Number of stall cycles.
-     */
-    void setStall(uint8_t cycles);
 
     // Pipeline stage methods
 
@@ -226,8 +222,10 @@ class FunctionalSimulator {
     /// Add flag for halt instruction
     bool halt_pipeline = false;
 
-    /// Countdown of the required stall cycles
-    uint8_t stall;
+    /// Stall signal
+    bool stall = false;
+
+    bool program_finished = false; 
 
     /**
      * @brief Helper method to check if an instruction writes to a register.
@@ -247,16 +245,24 @@ class FunctionalSimulator {
     uint32_t readRegisterValue(uint8_t reg_num);
 
     /* @brief Detects hazards in the pipeline and returns the number of stall cycles needed.
- * 
- * This method checks for data hazards between the stages of the pipeline. If a hazard is detected,
- * it returns the number of stall cycles required to resolve it. If no hazards are detected, it
- * returns 0.
- *
- * @return Number of stall cycles needed to resolve hazards, or 0 if no hazards are detected.
- */
-    int detectStalls(void);
-    
+    * 
+    * This method checks for data hazards between the stages of the pipeline. If a hazard is detected,
+    * it returns the number of stall cycles required to resolve it. If no hazards are detected, it
+    * returns 0.
+    *
+    * @return Number of stall cycles needed to resolve hazards, or 0 if no hazards are detected.
+    */
+    bool detectStalls(void);
+
+    // determines if the instruction needs the Rt register value as a source operand
     bool needsRtValue(const Instruction* instr) const;
+
+    /** check for program completion
+     * @brief Check if the program has finished executing. If so it will set 
+     * program_finished to true 
+     */
+    void checkProgramCompletion(void);
+
 
 
 

--- a/include/mips_lite_defs.h
+++ b/include/mips_lite_defs.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <cstdint>
+#include <stdexcept>
 
 namespace mips_lite {
 
@@ -104,6 +105,39 @@ inline InstructionType get_instruction_type(uint8_t opcode) {
             return InstructionType::R_TYPE;
         default:
             return InstructionType::I_TYPE;
+    }
+}
+
+inline InstructionCategory get_instruction_category(uint8_t opcode) {
+    switch (opcode) {
+        case opcode::ADD:
+        case opcode::ADDI:
+        case opcode::SUB:
+        case opcode::SUBI:
+        case opcode::MUL:
+        case opcode::MULI:
+            return InstructionCategory::ARITHMETIC;
+
+        case opcode::OR:
+        case opcode::ORI:
+        case opcode::AND:
+        case opcode::ANDI:
+        case opcode::XOR:
+        case opcode::XORI:
+            return InstructionCategory::LOGICAL;
+
+        case opcode::LDW:
+        case opcode::STW:
+            return InstructionCategory::MEMORY_ACCESS;
+
+        case opcode::BZ:
+        case opcode::BEQ:
+        case opcode::JR:
+        case opcode::HALT:
+            return InstructionCategory::CONTROL_FLOW;
+
+        default:
+            throw std::invalid_argument("Invalid opcode for instruction category");
     }
 }
 // Control Word Bit Positions

--- a/tests/functional_simulator/CMakeLists.txt
+++ b/tests/functional_simulator/CMakeLists.txt
@@ -27,4 +27,4 @@ create_simulator_test(exe_stage_tests exe_stage_tests.cpp)
 create_simulator_test(fetch_stage_tests fetch_stage_tests.cpp)
 
 # Add the integration tests later...
-# create_simulator_test(functional_simulator_integration_test functional_simulator_integration_tests.cpp)
+create_simulator_test(functional_simulator_integration_test functional_simulator_integration_tests.cpp)

--- a/tests/functional_simulator/functional_simulator_integration_tests.cpp
+++ b/tests/functional_simulator/functional_simulator_integration_tests.cpp
@@ -30,7 +30,7 @@ class IntegrationTest : public ::testing::Test {
     std::unique_ptr<FunctionalSimulator> sim_no_forward;
     std::unique_ptr<FunctionalSimulator> sim_with_forward;
 
-    void SetUp() override { 
+    void SetUp() override {
         sim_no_forward = std::make_unique<FunctionalSimulator>(&rf, &stats, &mem, false);
         sim_with_forward = std::make_unique<FunctionalSimulator>(&rf, &stats, &mem, true);
     }
@@ -63,15 +63,14 @@ void setupMockMemory(MockMemoryParser& mem, const std::vector<uint32_t>& memory,
     EXPECT_CALL(mem, readInstruction(::testing::_))
         .WillRepeatedly(::testing::Invoke(memory_lookup));
 
-    EXPECT_CALL(mem, readMemory(::testing::_))
-        .WillRepeatedly(::testing::Invoke(memory_lookup));
+    EXPECT_CALL(mem, readMemory(::testing::_)).WillRepeatedly(::testing::Invoke(memory_lookup));
 }
 
 /**
  * @brief Helper to reset simulator state for multiple test runs
  */
-void resetSimulator(std::unique_ptr<FunctionalSimulator>& sim, RegisterFile& rf, Stats& stats, 
-                   MockMemoryParser& mem, bool enable_forwarding) {
+void resetSimulator(std::unique_ptr<FunctionalSimulator>& sim, RegisterFile& rf, Stats& stats,
+                    MockMemoryParser& mem, bool enable_forwarding) {
     rf = RegisterFile();  // Reset register file
     stats = Stats();      // Reset stats
     sim = std::make_unique<FunctionalSimulator>(&rf, &stats, &mem, enable_forwarding);
@@ -82,71 +81,72 @@ void resetSimulator(std::unique_ptr<FunctionalSimulator>& sim, RegisterFile& rf,
 // ---------------------------
 
 /**
- * @brief Test branch not taken with both forwarding and no forwarding. 
- * Results: 
+ * @brief Test branch not taken with both forwarding and no forwarding.
+ * Results:
  * - No forwarding
- *    R1 = 20 , PC = 16 
+ *    R1 = 20 , PC = 16
  *    Cycles = 13
  *    Stalls = 4
- *    Branch Penalty = 0 
+ *    Branch Penalty = 0
  * - Forwarding
  *    R1 = 20 , PC = 16
  *    Cycles = 9
  *    Stalls = 0
  *    Branch Penalty = 0
- *   
+ *
  */
 TEST_F(IntegrationTest, BZNotTaken) {
-    if(!sim_no_forward || !sim_with_forward) {
+    if (!sim_no_forward || !sim_with_forward) {
         ADD_FAILURE() << "Simulator instances not initialized properly";
         FAIL();
-    }   
+    }
     std::vector<uint32_t> program = {
         0x04010004,  // ADDI R1 R0 4
-        0x38200002,  // BZ R1 2 
+        0x38200002,  // BZ R1 2
         0x04210006,  // ADDI R1 R1 6
-        0x0421000a,  // ADDI R1 R1 10  
-        0x44000000   // HALT 
+        0x0421000a,  // ADDI R1 R1 10
+        0x44000000   // HALT
     };
 
     setupMockMemory(mem, program);
 
     // Test without forwarding
-    while(!sim_no_forward->isProgramFinished()){
+    while (!sim_no_forward->isProgramFinished()) {
         sim_no_forward->cycle();
 
-        if(stats.getClockCycles() >= 1000) {
+        if (stats.getClockCycles() >= 1000) {
             ADD_FAILURE() << "Simulator did not halt within 1000 cycles";
             break;
         }
     }
-    
-    EXPECT_EQ(rf.read(1), 20); 
-    EXPECT_EQ(stats.getClockCycles(), 13); 
-    EXPECT_EQ(stats.getStalls(), 4); 
-    
+
+    EXPECT_EQ(rf.read(1), 20);
+    EXPECT_EQ(stats.getClockCycles(), 13);
+    EXPECT_EQ(stats.getStalls(), 4);
+    EXPECT_EQ(sim_no_forward->getPC(), 16);  // PC should be at HALT instruction
+
     // Reset and test with forwarding
     resetSimulator(sim_with_forward, rf, stats, mem, true);
     setupMockMemory(mem, program);  // Re-setup mock for new simulator instance
-    
-    while(!sim_with_forward->isProgramFinished()){
+
+    while (!sim_with_forward->isProgramFinished()) {
         sim_with_forward->cycle();
 
-        if(stats.getClockCycles() >= 1000) {
+        if (stats.getClockCycles() >= 1000) {
             ADD_FAILURE() << "Simulator did not halt within 1000 cycles";
             break;
         }
     }
-    
-    EXPECT_EQ(rf.read(1), 20);  // Same final result
-    EXPECT_EQ(stats.getClockCycles(), 9);  // Expected cycle count with forwarding
-    EXPECT_EQ(stats.getStalls(), 0);  // No stalls with forwarding
-    
+
+    EXPECT_EQ(rf.read(1), 20);                 // Same final result
+    EXPECT_EQ(stats.getClockCycles(), 9);      // Expected cycle count with forwarding
+    EXPECT_EQ(stats.getStalls(), 0);           // No stalls with forwarding
+    EXPECT_EQ(sim_with_forward->getPC(), 16);  // PC should be at HALT instruction
 }
 
 /**
- * @brief Test branch taken with both forwarding and no forwarding. 
- * Results: 
+ * @brief Test branch taken with both forwarding and no forwarding.
+ * Results:
  * - No forwarding
  * R1 = 10 , PC = 16
  * Cycles = 12
@@ -154,63 +154,63 @@ TEST_F(IntegrationTest, BZNotTaken) {
  * - Forwarding
  * R1 = 10 , PC = 16
  * Cycles = 10
- * Stalls = 0    
+ * Stalls = 0
  */
 TEST_F(IntegrationTest, BZTaken) {
-    if(!sim_no_forward || !sim_with_forward) {
+    if (!sim_no_forward || !sim_with_forward) {
         ADD_FAILURE() << "Simulator instances not initialized properly";
         FAIL();
     }
     std::vector<uint32_t> program = {
         0x00000800,  // ADD R1 R0 R0
-        0x38200002,  // BZ R1 2 
+        0x38200002,  // BZ R1 2
         0x04210006,  // ADDI R1 R1 6 <- Should get skipped
-        0x0421000A,  // ADDI R1 R1 10 
-        0x44000000   // HALT 
+        0x0421000A,  // ADDI R1 R1 10
+        0x44000000   // HALT
     };
 
     setupMockMemory(mem, program);
 
     // Test without forwarding
-    while(!sim_no_forward->isProgramFinished()){
+    while (!sim_no_forward->isProgramFinished()) {
         sim_no_forward->cycle();
 
-        if(stats.getClockCycles() >= 1000) {
+        if (stats.getClockCycles() >= 1000) {
             ADD_FAILURE() << "Simulator did not halt within 1000 cycles";
             break;
         }
     }
-    
-    EXPECT_EQ(rf.read(1), 10); 
-    EXPECT_EQ(stats.getClockCycles(), 12); 
-    EXPECT_EQ(stats.getStalls(), 2); 
+
+    EXPECT_EQ(rf.read(1), 10);
+    EXPECT_EQ(stats.getClockCycles(), 12);
+    EXPECT_EQ(stats.getStalls(), 2);
+    EXPECT_EQ(sim_no_forward->getPC(), 16);  // PC should be at HALT instruction
     // Add check for stats instruction categories
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 2);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 2);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::MEMORY_ACCESS), 0);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::LOGICAL), 0);
 
-    
     // Reset and test with forwarding
     resetSimulator(sim_with_forward, rf, stats, mem, true);
     setupMockMemory(mem, program);  // Re-setup mock for new simulator instance
-    
-    while(!sim_with_forward->isProgramFinished()){
+
+    while (!sim_with_forward->isProgramFinished()) {
         sim_with_forward->cycle();
 
-        if(stats.getClockCycles() >= 1000) {
+        if (stats.getClockCycles() >= 1000) {
             ADD_FAILURE() << "Simulator did not halt within 1000 cycles";
             break;
         }
     }
-    
-    EXPECT_EQ(rf.read(1), 10);  // Same final result
-    EXPECT_EQ(stats.getClockCycles(), 10);  // Expected cycle count with forwarding
-    EXPECT_EQ(stats.getStalls(), 0);  // No stalls with forwarding
+
+    EXPECT_EQ(rf.read(1), 10);                 // Same final result
+    EXPECT_EQ(stats.getClockCycles(), 10);     // Expected cycle count with forwarding
+    EXPECT_EQ(stats.getStalls(), 0);           // No stalls with forwarding
+    EXPECT_EQ(sim_with_forward->getPC(), 16);  // PC should be at HALT instruction
     // Add check for stats instruction categories
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 2);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 2);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::MEMORY_ACCESS), 0);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::LOGICAL), 0);
-
 }

--- a/tests/functional_simulator/functional_simulator_integration_tests.cpp
+++ b/tests/functional_simulator/functional_simulator_integration_tests.cpp
@@ -144,9 +144,13 @@ TEST_F(IntegrationTest, BZNotTaken) {
  * @brief Test branch taken with both forwarding and no forwarding. 
  * Results: 
  * - No forwarding
-
+ * R1 = 10 , PC = 16
+ * Cycles = 12
+ * Stalls = 2
  * - Forwarding
- *    
+ * R1 = 10 , PC = 16
+ * Cycles = 10
+ * Stalls = 0    
  */
 TEST_F(IntegrationTest, BZTaken) {
     std::vector<uint32_t> program = {
@@ -172,6 +176,12 @@ TEST_F(IntegrationTest, BZTaken) {
     EXPECT_EQ(rf.read(1), 10); 
     EXPECT_EQ(stats.getClockCycles(), 12); 
     EXPECT_EQ(stats.getStalls(), 2); 
+    // Add check for stats instruction categories
+    EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 2);
+    EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 2);
+    EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::MEMORY_ACCESS), 0);
+    EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::LOGICAL), 0);
+
     
     // Reset and test with forwarding
     resetSimulator(sim_with_forward, rf, stats, mem, true);
@@ -189,5 +199,10 @@ TEST_F(IntegrationTest, BZTaken) {
     EXPECT_EQ(rf.read(1), 10);  // Same final result
     EXPECT_EQ(stats.getClockCycles(), 10);  // Expected cycle count with forwarding
     EXPECT_EQ(stats.getStalls(), 0);  // No stalls with forwarding
+    // Add check for stats instruction categories
+    EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 2);
+    EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 2);
+    EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::MEMORY_ACCESS), 0);
+    EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::LOGICAL), 0);
 
 }

--- a/tests/functional_simulator/functional_simulator_integration_tests.cpp
+++ b/tests/functional_simulator/functional_simulator_integration_tests.cpp
@@ -97,6 +97,10 @@ void resetSimulator(std::unique_ptr<FunctionalSimulator>& sim, RegisterFile& rf,
  *   
  */
 TEST_F(IntegrationTest, BZNotTaken) {
+    if(!sim_no_forward || !sim_with_forward) {
+        ADD_FAILURE() << "Simulator instances not initialized properly";
+        FAIL();
+    }   
     std::vector<uint32_t> program = {
         0x04010004,  // ADDI R1 R0 4
         0x38200002,  // BZ R1 2 
@@ -153,6 +157,10 @@ TEST_F(IntegrationTest, BZNotTaken) {
  * Stalls = 0    
  */
 TEST_F(IntegrationTest, BZTaken) {
+    if(!sim_no_forward || !sim_with_forward) {
+        ADD_FAILURE() << "Simulator instances not initialized properly";
+        FAIL();
+    }
     std::vector<uint32_t> program = {
         0x00000800,  // ADD R1 R0 R0
         0x38200002,  // BZ R1 2 

--- a/tests/functional_simulator/functional_simulator_tests.cpp
+++ b/tests/functional_simulator/functional_simulator_tests.cpp
@@ -56,7 +56,6 @@ class FunctionalSimulatorTest : public ::testing::Test {
 
 TEST_F(FunctionalSimulatorTest, Initialization) {
     EXPECT_EQ(sim->getPC(), 0);
-    EXPECT_EQ(sim->getStall(), 0);
     EXPECT_FALSE(sim->isForwardingEnabled());
 }
 
@@ -69,10 +68,7 @@ TEST_F(FunctionalSimulatorTest, ForwardingFlag) {
 // Test setters and getters
 TEST_F(FunctionalSimulatorTest, SettersAndGetters) {
     sim->setPC(0x00400020);
-    sim->setStall(3);
-
     EXPECT_EQ(sim->getPC(), 0x00400020);
-    EXPECT_EQ(sim->getStall(), 3);
 }
 
 // Test pipeline stages initially empty
@@ -89,22 +85,6 @@ TEST_F(FunctionalSimulatorTest, BoundsChecking) {
     EXPECT_THROW(sim->isStageEmpty(5), std::out_of_range);
     EXPECT_THROW(sim->getPipelineStage(-1), std::out_of_range);
     EXPECT_THROW(sim->getPipelineStage(5), std::out_of_range);
-}
-
-// Test stall counter decrements
-TEST_F(FunctionalSimulatorTest, StallDecrement) {
-    sim->setStall(2);
-    EXPECT_EQ(sim->getStall(), 2);
-
-    sim->advancePipeline();
-    EXPECT_EQ(sim->getStall(), 1);
-
-    sim->advancePipeline();
-    EXPECT_EQ(sim->getStall(), 0);
-
-    // Should not go below zero
-    sim->advancePipeline();
-    EXPECT_EQ(sim->getStall(), 0);
 }
 
 // Test that getPipelineStage returns nullptr for empty stages

--- a/tests/functional_simulator/functional_simulator_tests.cpp
+++ b/tests/functional_simulator/functional_simulator_tests.cpp
@@ -113,7 +113,8 @@ TEST_F(FunctionalSimulatorTest, WriteBackWritesToRegisterAndUpdatesStats) {
     auto data = std::make_unique<PipelineStageData>();
     data->alu_result = expected_value;
     data->dest_reg = dest_reg;
-    data->instruction = std::make_unique<Instruction>(0x6789ABCD);
+    data->instruction =
+        std::make_unique<Instruction>(mips_lite::opcode::ADDI << 26);  // Dummy opcode
     sim->getPipeline()[FunctionalSimulator::WRITEBACK] = std::move(data);
 
     sim->writeBack();
@@ -140,7 +141,8 @@ TEST_F(FunctionalSimulatorTest, WriteBackEmptyDestRegReturns) {
     // writing to the register file.
     auto data = std::make_unique<PipelineStageData>();
     data->alu_result = expected_value;
-    data->instruction = std::make_unique<Instruction>(0x6789ABCD);
+    data->instruction =
+        std::make_unique<Instruction>(mips_lite::opcode::ADDI << 26);  // Dummy opcode
     sim->getPipeline()[FunctionalSimulator::WRITEBACK] = std::move(data);
 
     sim->writeBack();


### PR DESCRIPTION
This pull request should mostly finish up our functional simulator. I've made changes as follows: 

- Created pipeline control logic in `cycle()` and `advancePipeline()` methods. 
- Changed stall counter to be a boolean
- Added a few tests to fs integration test suite
- Added helper for getting instruction categories to add to our stats class 

My main goal was to get this posted and figured we could all write and work through more test cases. For this, I think a debugger is necessary which makes things tedious but probably our best bet at finding bugs when a test fails.


### TODOs: 
- Add more test coverage
- Integrate changes with main.cpp
