### PR TITLE
Added integration test for raw caused by load; fixed bug discovered from test

### DIFF
--- a/tests/functional_simulator/functional_simulator_integration_tests.cpp
+++ b/tests/functional_simulator/functional_simulator_integration_tests.cpp
@@ -74,24 +74,21 @@ void setupMockMemory(MockMemoryParser& mem, const std::vector<uint32_t>& instruc
     auto data_lookup = [&instructions, &data_memory, instruction_base](uint32_t addr) -> uint32_t {
         // If data_memory is provided and not empty, use separate data memory logic
         if (!data_memory.empty()) {
-            // Align address to word boundary by converting word index to byte address
-            uint32_t word_index = addr / 4;
-            uint32_t aligned_addr = word_index << 2;  // word_index * 4
-
-            auto it = data_memory.find(aligned_addr);
+            auto it = data_memory.find(addr);
             if (it != data_memory.end()) {
                 return it->second;
             } else {
                 ADD_FAILURE()
-                    << "Data memory access to uninitialized address: 0x" << std::hex << aligned_addr
+                    << "Data memory access to uninitialized address: 0x" << std::hex << addr
                     << " (original: 0x" << std::hex << addr
                     << "). Please add this address to your data_memory map in the test setup.";
                 throw std::runtime_error("Access to uninitialized data memory");
             }
-        } else {
+        } else {  //[DEFAULT]
             // If data memory is not provided, use instruction memory. This is a fallback, and
             // ensures tests can still read instructions as data if no specific data memory is set
-            // up. Hence, load/stores can still read or write to instruction memory.
+            // up. Hence, load/stores can still read or write to instruction memory as in project
+            // specs.
             size_t index = (addr - instruction_base) / 4;
             if ((addr - instruction_base) % 4 != 0) {
                 ADD_FAILURE() << "Unaligned memory access at address: 0x" << std::hex << addr;

--- a/tests/functional_simulator/functional_simulator_integration_tests.cpp
+++ b/tests/functional_simulator/functional_simulator_integration_tests.cpp
@@ -71,7 +71,7 @@ void setupMockMemory(MockMemoryParser& mem, const std::vector<uint32_t>& instruc
     };
 
     // Data memory handler
-    auto data_lookup = [&instructions, &data_memory, instruction_base](uint32_t addr) -> uint32_t {
+    auto data_lookup = [&data_memory, &instruction_lookup](uint32_t addr) -> uint32_t {
         // If data_memory is provided and not empty, use separate data memory logic
         if (!data_memory.empty()) {
             auto it = data_memory.find(addr);
@@ -89,16 +89,7 @@ void setupMockMemory(MockMemoryParser& mem, const std::vector<uint32_t>& instruc
             // ensures tests can still read instructions as data if no specific data memory is set
             // up. Hence, load/stores can still read or write to instruction memory as in project
             // specs.
-            size_t index = (addr - instruction_base) / 4;
-            if ((addr - instruction_base) % 4 != 0) {
-                ADD_FAILURE() << "Unaligned memory access at address: 0x" << std::hex << addr;
-                throw std::runtime_error("Unaligned access");
-            }
-            if (index >= instructions.size()) {
-                ADD_FAILURE() << "Memory access out of bounds at address: 0x" << std::hex << addr;
-                throw std::out_of_range("Access outside memory vector");
-            }
-            return instructions[index];
+            return instruction_lookup(addr);
         }
     };
 


### PR DESCRIPTION
@nkanderson You were correct, the forwarding logic didn't account for forwarding of memory data when the instruction is a load. I created the issue with my raw caused by load test, which confirmed it was failing for this very reason; I fixed this bug and now my test is passing. 

Other changes: 
- Expanded integration test memory mock so that tests can be setup with specific memory conditions. It is optional to provide memory data and defaults back to treating instructions and memory data as the same to maintain compatibility between tests. 
