### PR TITLE
Change location of PC update to match provided output

### DIFF
--- a/src/functional_simulator.cpp
+++ b/src/functional_simulator.cpp
@@ -64,6 +64,7 @@ void FunctionalSimulator::instructionFetch() {
     }
 
     uint32_t instruction_word = memory_parser->readInstruction(pc);
+
     halt_pipeline = mips_lite::is_halt_instruction(instruction_word);
 
     // Create next instruction for pipeline
@@ -73,9 +74,7 @@ void FunctionalSimulator::instructionFetch() {
     stage_data->pc = pc;
 
     fetch_data = std::move(stage_data);
-    if (!halt_pipeline) {
-        pc += 4;
-    }
+    pc += 4;
 }
 
 void FunctionalSimulator::instructionDecode() {
@@ -406,7 +405,7 @@ bool FunctionalSimulator::isRegisterWriteInstruction(const Instruction* instr) c
 uint32_t FunctionalSimulator::readRegisterValue(uint8_t reg_num) {
     if (reg_num == 0) {
         return 0;  // $0 register always returns 0
-    }  // And never has hazards
+    }              // And never has hazards
     if (stall) {
         throw std::runtime_error(
             "Stall detected in ID stage but wasn't properly handled by control logic. Should "

--- a/tests/functional_simulator/fetch_stage_tests.cpp
+++ b/tests/functional_simulator/fetch_stage_tests.cpp
@@ -33,26 +33,20 @@ class FetchStageTest : public ::testing::Test {
     std::unique_ptr<FunctionalSimulator> sim;
 
     // Reusing instruction encodings from your existing tests
-    static constexpr uint32_t ADD_INSTR = 0x00221800;      // ADD $3, $1, $2
-    static constexpr uint32_t ADDI_INSTR = 0x04850064;     // ADDI $5, $4, 100
-    static constexpr uint32_t SUB_INSTR = 0x08221800;      // SUB $3, $1, $2
-    static constexpr uint32_t HALT_INSTR = 0x44000000;     // HALT
+    static constexpr uint32_t ADD_INSTR = 0x00221800;   // ADD $3, $1, $2
+    static constexpr uint32_t ADDI_INSTR = 0x04850064;  // ADDI $5, $4, 100
+    static constexpr uint32_t SUB_INSTR = 0x08221800;   // SUB $3, $1, $2
+    static constexpr uint32_t HALT_INSTR = 0x44000000;  // HALT
 
-    void SetUp() override {
-        sim = std::make_unique<FunctionalSimulator>(&rf, &stats, &mem, false);
-    }
+    void SetUp() override { sim = std::make_unique<FunctionalSimulator>(&rf, &stats, &mem, false); }
 };
 
 TEST_F(FetchStageTest, FetchFourInstructions) {
     // Set up memory to return our 4 instructions in sequence
-    EXPECT_CALL(mem, readInstruction(0x0))
-        .WillOnce(Return(ADD_INSTR));
-    EXPECT_CALL(mem, readInstruction(0x4))
-        .WillOnce(Return(ADDI_INSTR));  
-    EXPECT_CALL(mem, readInstruction(0x8))
-        .WillOnce(Return(SUB_INSTR));
-    EXPECT_CALL(mem, readInstruction(0xC))
-        .WillOnce(Return(HALT_INSTR));
+    EXPECT_CALL(mem, readInstruction(0x0)).WillOnce(Return(ADD_INSTR));
+    EXPECT_CALL(mem, readInstruction(0x4)).WillOnce(Return(ADDI_INSTR));
+    EXPECT_CALL(mem, readInstruction(0x8)).WillOnce(Return(SUB_INSTR));
+    EXPECT_CALL(mem, readInstruction(0xC)).WillOnce(Return(HALT_INSTR));
 
     // Initially, PC should be 0 and fetch stage should be empty
     EXPECT_EQ(sim->getPC(), 0);
@@ -62,8 +56,9 @@ TEST_F(FetchStageTest, FetchFourInstructions) {
     sim->instructionFetch();
     EXPECT_EQ(sim->getPC(), 4);  // PC should increment
     EXPECT_FALSE(sim->isStageEmpty(FunctionalSimulator::PipelineStage::FETCH));
-    
-    const PipelineStageData* fetch_data = sim->getPipelineStage(FunctionalSimulator::PipelineStage::FETCH);
+
+    const PipelineStageData* fetch_data =
+        sim->getPipelineStage(FunctionalSimulator::PipelineStage::FETCH);
     ASSERT_NE(fetch_data, nullptr);
     EXPECT_EQ(fetch_data->instruction->getOpcode(), mips_lite::opcode::ADD);
     EXPECT_EQ(fetch_data->pc, 0);  // Should store the PC where instruction was fetched

--- a/tests/functional_simulator/fetch_stage_tests.cpp
+++ b/tests/functional_simulator/fetch_stage_tests.cpp
@@ -97,9 +97,9 @@ TEST_F(FetchStageTest, FetchFourInstructions) {
     // Fetch fourth instruction (HALT) - should set halt_pipeline flag
     EXPECT_FALSE(sim->isHalted());  // Should not be halted yet
     sim->instructionFetch();
-    EXPECT_EQ(sim->getPC(), 12);  // PC should not increment after HALT
-    EXPECT_TRUE(sim->isHalted());   // Now should be set to halt
-    
+    EXPECT_EQ(sim->getPC(), 16);   // PC should increment once more after HALT
+    EXPECT_TRUE(sim->isHalted());  // Now should be set to halt
+
     fetch_data = sim->getPipelineStage(FunctionalSimulator::PipelineStage::FETCH);
     ASSERT_NE(fetch_data, nullptr);
     EXPECT_EQ(fetch_data->instruction->getOpcode(), mips_lite::opcode::HALT);
@@ -108,6 +108,6 @@ TEST_F(FetchStageTest, FetchFourInstructions) {
     // Try to fetch again - should do nothing because halt_pipeline is true
     sim->advancePipeline();
     sim->instructionFetch();
-    EXPECT_EQ(sim->getPC(), 12);  // PC should not change
+    EXPECT_EQ(sim->getPC(), 16);  // PC should increment once more after HALT
     EXPECT_TRUE(sim->isStageEmpty(FunctionalSimulator::PipelineStage::FETCH));  // Should not fetch
 }

--- a/tests/functional_simulator/functional_simulator_integration_tests.cpp
+++ b/tests/functional_simulator/functional_simulator_integration_tests.cpp
@@ -131,9 +131,9 @@ void resetSimulator(std::unique_ptr<FunctionalSimulator>& sim, RegisterFile& rf,
  * R8 = 0
  *
  * - No forwarding
- * PC = 32, Cycles = 14, Stalls = 1
+ * PC = 36, Cycles = 14, Stalls = 1
  * - Forwarding
- * PC = 32, Cycles = 13, Stalls = 0
+ * PC = 36, Cycles = 13, Stalls = 0
  */
 TEST_F(IntegrationTest, ADDSeq) {
     if (!sim_no_forward || !sim_with_forward) {
@@ -173,7 +173,7 @@ TEST_F(IntegrationTest, ADDSeq) {
     EXPECT_EQ(rf.read(8), 0);
     EXPECT_EQ(stats.getClockCycles(), 14);
     EXPECT_EQ(stats.getStalls(), 1);
-    EXPECT_EQ(sim_no_forward->getPC(), 32);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_no_forward->getPC(), 36);  // PC should one instruction beyond HALT
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 1);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 8);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::MEMORY_ACCESS), 0);
@@ -202,7 +202,7 @@ TEST_F(IntegrationTest, ADDSeq) {
     EXPECT_EQ(rf.read(8), 0);
     EXPECT_EQ(stats.getClockCycles(), 13);
     EXPECT_EQ(stats.getStalls(), 0);
-    EXPECT_EQ(sim_no_forward->getPC(), 32);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_no_forward->getPC(), 36);  // PC should one instruction beyond HALT
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 1);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 8);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::MEMORY_ACCESS), 0);
@@ -221,9 +221,9 @@ TEST_F(IntegrationTest, ADDSeq) {
  * R6 = 0
  *
  * - No forwarding
- * PC = 24, Cycles = 12, Stalls = 1
+ * PC = 28, Cycles = 12, Stalls = 1
  * - Forwarding
- * PC = 24, Cycles = 11, Stalls = 0
+ * PC = 28, Cycles = 11, Stalls = 0
  */
 TEST_F(IntegrationTest, ADDISeq) {
     if (!sim_no_forward || !sim_with_forward) {
@@ -259,7 +259,7 @@ TEST_F(IntegrationTest, ADDISeq) {
     EXPECT_EQ(rf.read(6), 0);
     EXPECT_EQ(stats.getClockCycles(), 12);
     EXPECT_EQ(stats.getStalls(), 1);
-    EXPECT_EQ(sim_no_forward->getPC(), 24);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_no_forward->getPC(), 28);  // PC should one instruction beyond HALT
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 1);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 6);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::MEMORY_ACCESS), 0);
@@ -286,7 +286,7 @@ TEST_F(IntegrationTest, ADDISeq) {
     EXPECT_EQ(rf.read(6), 0);
     EXPECT_EQ(stats.getClockCycles(), 11);
     EXPECT_EQ(stats.getStalls(), 0);
-    EXPECT_EQ(sim_no_forward->getPC(), 24);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_no_forward->getPC(), 28);  // PC should one instruction beyond HALT
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 1);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 6);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::MEMORY_ACCESS), 0);
@@ -307,9 +307,9 @@ TEST_F(IntegrationTest, ADDISeq) {
  * R8 = 0
  *
  * - No forwarding
- * PC = 32, Cycles = 14, Stalls = 1
+ * PC = 36, Cycles = 14, Stalls = 1
  * - Forwarding
- * PC = 32, Cycles = 13, Stalls = 0
+ * PC = 36, Cycles = 13, Stalls = 0
  */
 TEST_F(IntegrationTest, SUBSeq) {
     if (!sim_no_forward || !sim_with_forward) {
@@ -349,7 +349,7 @@ TEST_F(IntegrationTest, SUBSeq) {
     EXPECT_EQ(rf.read(8), 0);
     EXPECT_EQ(stats.getClockCycles(), 14);
     EXPECT_EQ(stats.getStalls(), 1);
-    EXPECT_EQ(sim_no_forward->getPC(), 32);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_no_forward->getPC(), 36);  // PC should one instruction beyond HALT
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 1);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 8);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::MEMORY_ACCESS), 0);
@@ -378,7 +378,7 @@ TEST_F(IntegrationTest, SUBSeq) {
     EXPECT_EQ(rf.read(8), 0);
     EXPECT_EQ(stats.getClockCycles(), 13);
     EXPECT_EQ(stats.getStalls(), 0);
-    EXPECT_EQ(sim_no_forward->getPC(), 32);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_no_forward->getPC(), 36);  // PC should one instruction beyond HALT
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 1);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 8);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::MEMORY_ACCESS), 0);
@@ -397,9 +397,9 @@ TEST_F(IntegrationTest, SUBSeq) {
  * R6 = 0
  *
  * - No forwarding
- * PC = 24, Cycles = 12, Stalls = 1
+ * PC = 28, Cycles = 12, Stalls = 1
  * - Forwarding
- * PC = 24, Cycles = 11, Stalls = 0
+ * PC = 28, Cycles = 11, Stalls = 0
  */
 TEST_F(IntegrationTest, SUBISeq) {
     if (!sim_no_forward || !sim_with_forward) {
@@ -435,7 +435,7 @@ TEST_F(IntegrationTest, SUBISeq) {
     EXPECT_EQ(rf.read(6), 0);
     EXPECT_EQ(stats.getClockCycles(), 12);
     EXPECT_EQ(stats.getStalls(), 1);
-    EXPECT_EQ(sim_no_forward->getPC(), 24);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_no_forward->getPC(), 28);  // PC should one instruction beyond HALT
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 1);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 6);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::MEMORY_ACCESS), 0);
@@ -462,7 +462,7 @@ TEST_F(IntegrationTest, SUBISeq) {
     EXPECT_EQ(rf.read(6), 0);
     EXPECT_EQ(stats.getClockCycles(), 11);
     EXPECT_EQ(stats.getStalls(), 0);
-    EXPECT_EQ(sim_no_forward->getPC(), 24);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_no_forward->getPC(), 28);  // PC should one instruction beyond HALT
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 1);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 6);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::MEMORY_ACCESS), 0);
@@ -486,7 +486,7 @@ TEST_F(IntegrationTest, SUBISeq) {
  * R10 = 5
  *
  * - No forwarding and Forwarding
- * PC = 40, Cycles = 15, Stalls = 0
+ * PC = 44, Cycles = 15, Stalls = 0
  */
 TEST_F(IntegrationTest, MULSeq) {
     if (!sim_no_forward || !sim_with_forward) {
@@ -530,7 +530,7 @@ TEST_F(IntegrationTest, MULSeq) {
     EXPECT_EQ(rf.read(10), 5);
     EXPECT_EQ(stats.getClockCycles(), 15);
     EXPECT_EQ(stats.getStalls(), 0);
-    EXPECT_EQ(sim_no_forward->getPC(), 40);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_no_forward->getPC(), 44);  // PC should one instruction beyond HALT
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 1);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 10);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::MEMORY_ACCESS), 0);
@@ -561,7 +561,7 @@ TEST_F(IntegrationTest, MULSeq) {
     EXPECT_EQ(rf.read(10), 5);
     EXPECT_EQ(stats.getClockCycles(), 15);
     EXPECT_EQ(stats.getStalls(), 0);
-    EXPECT_EQ(sim_no_forward->getPC(), 40);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_no_forward->getPC(), 44);  // PC should one instruction beyond HALT
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 1);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 10);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::MEMORY_ACCESS), 0);
@@ -582,9 +582,9 @@ TEST_F(IntegrationTest, MULSeq) {
  * R7 = 5
  *
  * - No forwarding
- * PC = 28, Cycles = 13, Stalls = 1
+ * PC = 32, Cycles = 13, Stalls = 1
  * - Forwarding
- * PC = 28, Cycles = 12, Stalls = 0
+ * PC = 32, Cycles = 12, Stalls = 0
  */
 TEST_F(IntegrationTest, MULISeq) {
     if (!sim_no_forward || !sim_with_forward) {
@@ -622,7 +622,7 @@ TEST_F(IntegrationTest, MULISeq) {
     EXPECT_EQ(rf.read(7), 5);
     EXPECT_EQ(stats.getClockCycles(), 13);
     EXPECT_EQ(stats.getStalls(), 1);
-    EXPECT_EQ(sim_no_forward->getPC(), 28);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_no_forward->getPC(), 32);  // PC should one instruction beyond HALT
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 1);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 7);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::MEMORY_ACCESS), 0);
@@ -650,7 +650,7 @@ TEST_F(IntegrationTest, MULISeq) {
     EXPECT_EQ(rf.read(7), 5);
     EXPECT_EQ(stats.getClockCycles(), 12);
     EXPECT_EQ(stats.getStalls(), 0);
-    EXPECT_EQ(sim_no_forward->getPC(), 28);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_no_forward->getPC(), 32);  // PC should one instruction beyond HALT
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 1);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 7);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::MEMORY_ACCESS), 0);
@@ -669,7 +669,7 @@ TEST_F(IntegrationTest, MULISeq) {
  *
  * R1 = 20
  * R2 = 8
- * PC = 20
+ * PC = 24
  */
 TEST_F(IntegrationTest, BEQNotTaken) {
     if (!sim_no_forward || !sim_with_forward) {
@@ -701,7 +701,7 @@ TEST_F(IntegrationTest, BEQNotTaken) {
     EXPECT_EQ(rf.read(2), 8);
     EXPECT_EQ(stats.getClockCycles(), 14);
     EXPECT_EQ(stats.getStalls(), 4);
-    EXPECT_EQ(sim_no_forward->getPC(), 20);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_no_forward->getPC(), 24);  // PC should one instruction beyond HALT
     // Add check for stats instruction categories
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 2);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 4);
@@ -725,7 +725,7 @@ TEST_F(IntegrationTest, BEQNotTaken) {
     EXPECT_EQ(rf.read(2), 8);
     EXPECT_EQ(stats.getClockCycles(), 10);     // Expected cycle count with forwarding
     EXPECT_EQ(stats.getStalls(), 0);           // No stalls with forwarding
-    EXPECT_EQ(sim_with_forward->getPC(), 20);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_with_forward->getPC(), 24);  // PC should one instruction beyond HALT
     // Add check for stats instruction categories
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 2);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 4);
@@ -745,7 +745,7 @@ TEST_F(IntegrationTest, BEQNotTaken) {
  *
  * R1 = 14
  * R2 = 4
- * PC = 20
+ * PC = 24
  */
 TEST_F(IntegrationTest, BEQTaken) {
     if (!sim_no_forward || !sim_with_forward) {
@@ -777,7 +777,7 @@ TEST_F(IntegrationTest, BEQTaken) {
     EXPECT_EQ(rf.read(2), 4);
     EXPECT_EQ(stats.getClockCycles(), 13);
     EXPECT_EQ(stats.getStalls(), 2);
-    EXPECT_EQ(sim_no_forward->getPC(), 20);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_no_forward->getPC(), 24);  // PC should one instruction beyond HALT
     // Add check for stats instruction categories
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 2);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 3);
@@ -801,7 +801,7 @@ TEST_F(IntegrationTest, BEQTaken) {
     EXPECT_EQ(rf.read(2), 4);
     EXPECT_EQ(stats.getClockCycles(), 11);     // Expected cycle count with forwarding
     EXPECT_EQ(stats.getStalls(), 0);           // No stalls with forwarding
-    EXPECT_EQ(sim_with_forward->getPC(), 20);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_with_forward->getPC(), 24);  // PC should one instruction beyond HALT
     // Add check for stats instruction categories
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 2);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 3);
@@ -813,12 +813,12 @@ TEST_F(IntegrationTest, BEQTaken) {
  * @brief Test BZ not taken with both forwarding and no forwarding.
  * Results:
  * - No forwarding
- *    R1 = 20 , PC = 16
+ *    R1 = 20 , PC = 20
  *    Cycles = 13
  *    Stalls = 4
  *    Branch Penalty = 0
  * - Forwarding
- *    R1 = 20 , PC = 16
+ *    R1 = 20 , PC = 20
  *    Cycles = 9
  *    Stalls = 0
  *    Branch Penalty = 0
@@ -852,7 +852,7 @@ TEST_F(IntegrationTest, BZNotTaken) {
     EXPECT_EQ(rf.read(1), 20);
     EXPECT_EQ(stats.getClockCycles(), 13);
     EXPECT_EQ(stats.getStalls(), 4);
-    EXPECT_EQ(sim_no_forward->getPC(), 16);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_no_forward->getPC(), 20);  // PC should one instruction beyond HALT
     // Add check for stats instruction categories
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 2);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 3);
@@ -875,7 +875,7 @@ TEST_F(IntegrationTest, BZNotTaken) {
     EXPECT_EQ(rf.read(1), 20);                 // Same final result
     EXPECT_EQ(stats.getClockCycles(), 9);      // Expected cycle count with forwarding
     EXPECT_EQ(stats.getStalls(), 0);           // No stalls with forwarding
-    EXPECT_EQ(sim_with_forward->getPC(), 16);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_with_forward->getPC(), 20);  // PC should one instruction beyond HALT
     // Add check for stats instruction categories
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 2);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 3);
@@ -887,11 +887,11 @@ TEST_F(IntegrationTest, BZNotTaken) {
  * @brief Test BZ taken with both forwarding and no forwarding.
  * Results:
  * - No forwarding
- * R1 = 10 , PC = 16
+ * R1 = 10 , PC = 20
  * Cycles = 12
  * Stalls = 2
  * - Forwarding
- * R1 = 10 , PC = 16
+ * R1 = 10 , PC = 20
  * Cycles = 10
  * Stalls = 0
  */
@@ -923,7 +923,7 @@ TEST_F(IntegrationTest, BZTaken) {
     EXPECT_EQ(rf.read(1), 10);
     EXPECT_EQ(stats.getClockCycles(), 12);
     EXPECT_EQ(stats.getStalls(), 2);
-    EXPECT_EQ(sim_no_forward->getPC(), 16);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_no_forward->getPC(), 20);  // PC should one instruction beyond HALT
     // Add check for stats instruction categories
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 2);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 2);
@@ -946,7 +946,7 @@ TEST_F(IntegrationTest, BZTaken) {
     EXPECT_EQ(rf.read(1), 10);                 // Same final result
     EXPECT_EQ(stats.getClockCycles(), 10);     // Expected cycle count with forwarding
     EXPECT_EQ(stats.getStalls(), 0);           // No stalls with forwarding
-    EXPECT_EQ(sim_with_forward->getPC(), 16);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_with_forward->getPC(), 20);  // PC should one instruction beyond HALT
     // Add check for stats instruction categories
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 2);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 2);
@@ -966,7 +966,7 @@ TEST_F(IntegrationTest, BZTaken) {
  *
  * R1 = 16
  * R2 = 10
- * PC = 20
+ * PC = 24
  */
 TEST_F(IntegrationTest, JRUnconditionalBranch) {
     if (!sim_no_forward || !sim_with_forward) {
@@ -998,7 +998,7 @@ TEST_F(IntegrationTest, JRUnconditionalBranch) {
     EXPECT_EQ(rf.read(2), 10);
     EXPECT_EQ(stats.getClockCycles(), 13);
     EXPECT_EQ(stats.getStalls(), 2);
-    EXPECT_EQ(sim_no_forward->getPC(), 20);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_no_forward->getPC(), 24);  // PC should one instruction beyond HALT
     // Add check for stats instruction categories
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 2);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 3);
@@ -1022,7 +1022,7 @@ TEST_F(IntegrationTest, JRUnconditionalBranch) {
     EXPECT_EQ(rf.read(2), 10);
     EXPECT_EQ(stats.getClockCycles(), 11);     // Expected cycle count with forwarding
     EXPECT_EQ(stats.getStalls(), 0);           // No stalls with forwarding
-    EXPECT_EQ(sim_with_forward->getPC(), 20);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_with_forward->getPC(), 24);  // PC should one instruction beyond HALT
     // Add check for stats instruction categories
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 2);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 3);
@@ -1068,7 +1068,7 @@ TEST_F(IntegrationTest, rawCausedByLoad) {
     EXPECT_EQ(rf.read(9), 10);  // R9 = 40 - 30 = 10
     EXPECT_EQ(stats.getStalls(), 4);
     EXPECT_EQ(stats.getClockCycles(), 12);
-    EXPECT_EQ(sim_no_forward->getPC(), 12);
+    EXPECT_EQ(sim_no_forward->getPC(), 16);
 
     // Test with forwarding
     resetSimulator(sim_with_forward, rf, stats, mem, true);
@@ -1087,7 +1087,7 @@ TEST_F(IntegrationTest, rawCausedByLoad) {
     EXPECT_EQ(rf.read(9), 10);        // R9 = 40 - 30 = 10
     EXPECT_EQ(stats.getStalls(), 1);  // Only 1 stall due to load
     EXPECT_EQ(stats.getClockCycles(), 9);
-    EXPECT_EQ(sim_with_forward->getPC(), 12);  // PC should be at HALT instruction
+    EXPECT_EQ(sim_with_forward->getPC(), 16);  // PC should one instruction beyond HALT
 }
 
 /**
@@ -1124,7 +1124,7 @@ TEST_F(IntegrationTest, rawDependencyChaining) {
     EXPECT_EQ(rf.read(6), 30);
     EXPECT_EQ(rf.read(7), 30);
     // Check timing & Stats
-    EXPECT_EQ(sim_no_forward->getPC(), 28);
+    EXPECT_EQ(sim_no_forward->getPC(), 32);
     EXPECT_EQ(stats.getStalls(), 12);
     EXPECT_EQ(stats.getClockCycles(), 24);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 4);
@@ -1154,7 +1154,7 @@ TEST_F(IntegrationTest, rawDependencyChaining) {
     EXPECT_EQ(rf.read(6), 30);
     EXPECT_EQ(rf.read(7), 30);
     // Check timing & Stats
-    EXPECT_EQ(sim_no_forward->getPC(), 28);
+    EXPECT_EQ(sim_no_forward->getPC(), 32);
     EXPECT_EQ(stats.getClockCycles(), 12);
     EXPECT_EQ(stats.getStalls(), 0);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC), 4);
@@ -1162,4 +1162,3 @@ TEST_F(IntegrationTest, rawDependencyChaining) {
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW), 1);
     EXPECT_EQ(stats.getCategoryCount(mips_lite::InstructionCategory::MEMORY_ACCESS), 0);
 }
-


### PR DESCRIPTION
Incrementing the PC prior to updating the halt_pipeline control allows for one final PC update beyond the HALT instruction, which matches the provided sample memory image output.

Screenshots below capture output, showing the PC value that's the same as in our provided sample output pngs from canvase.

![Screenshot 2025-05-31 at 2 36 07 PM](https://github.com/user-attachments/assets/3032e7ef-d0a7-4d3e-b258-112c2c37e065)
![Screenshot 2025-05-31 at 2 35 57 PM](https://github.com/user-attachments/assets/bf488d27-dfb6-430f-8dd3-55b963d58f00)
