### PR TITLE
Fixing negative number printing in main.cpp

### DIFF
--- a/docs/final-demo-output.txt
+++ b/docs/final-demo-output.txt
@@ -1,0 +1,300 @@
+MIPS-lite on  main via △ v4.0.2 
+❯ ./build/Debug/bin/mips_simulator -i traces/hex/final-demo.txt 
+Current Settings: 
+         Input Filepath:        traces/hex/final-demo.txt
+         Output Filepath:       output/traceout.txt
+         Print Memory Contents: DISABLED
+         Print Timing Info:     DISABLED
+         Forwarding:            DISABLED
+
+Instruction Counts:
+
+        Total number of instructions:   911
+        Arithmetic instructions:        375
+        Logical instructions:           61
+        Memory Access instructions:     300
+        Control Flow instructions:      175
+
+Final Register State:
+
+        Program Counter:        112
+        R11: 1044
+        R12: 1836
+        R13: 2640
+        R14: 25
+        R15: 4294967108
+        R16: 213
+        R17: 29
+        R18: 3440
+        R19: 4294967295
+        R20: 4294967294
+        R21: 4294967295
+        R22: 76
+        R23: 3
+        R24: 4294967295
+        R25: 3
+        Address: 2400, Contents: 2
+        Address: 2404, Contents: 4
+        Address: 2408, Contents: 6
+        Address: 2412, Contents: 8
+        Address: 2416, Contents: 10
+        Address: 2420, Contents: 12
+        Address: 2424, Contents: 14
+        Address: 2428, Contents: 16
+        Address: 2432, Contents: 18
+        Address: 2436, Contents: 29
+        Address: 2440, Contents: 22
+        Address: 2444, Contents: 24
+        Address: 2448, Contents: 26
+        Address: 2452, Contents: 28
+        Address: 2456, Contents: 30
+        Address: 2460, Contents: 32
+        Address: 2464, Contents: 34
+        Address: 2468, Contents: 36
+        Address: 2472, Contents: 38
+        Address: 2476, Contents: 59
+        Address: 2480, Contents: 42
+        Address: 2484, Contents: 44
+        Address: 2488, Contents: 46
+        Address: 2492, Contents: 48
+        Address: 2496, Contents: 50
+        Address: 2500, Contents: 52
+        Address: 2504, Contents: 54
+        Address: 2508, Contents: 56
+        Address: 2512, Contents: 58
+        Address: 2516, Contents: 89
+        Address: 2520, Contents: 62
+        Address: 2524, Contents: 64
+        Address: 2528, Contents: 66
+        Address: 2532, Contents: 68
+        Address: 2536, Contents: 70
+        Address: 2540, Contents: 72
+        Address: 2544, Contents: 74
+        Address: 2548, Contents: 76
+        Address: 2552, Contents: 78
+        Address: 2556, Contents: 119
+        Address: 2560, Contents: 82
+        Address: 2564, Contents: 84
+        Address: 2568, Contents: 86
+        Address: 2572, Contents: 88
+        Address: 2576, Contents: 90
+        Address: 2580, Contents: 92
+        Address: 2584, Contents: 94
+        Address: 2588, Contents: 96
+        Address: 2592, Contents: 98
+        Address: 2596, Contents: 149
+        Address: 2600, Contents: 2
+        Address: 2604, Contents: 4
+        Address: 2608, Contents: 6
+        Address: 2612, Contents: 8
+        Address: 2616, Contents: 10
+        Address: 2620, Contents: 12
+        Address: 2624, Contents: 14
+        Address: 2628, Contents: 16
+        Address: 2632, Contents: 18
+        Address: 2636, Contents: 29
+
+MIPS-lite on  main [?] via △ v4.0.2 
+❯ ./build/Debug/bin/mips_simulator -i traces/hex/final-demo.txt -t
+Current Settings: 
+         Input Filepath:        traces/hex/final-demo.txt
+         Output Filepath:       output/traceout.txt
+         Print Memory Contents: DISABLED
+         Print Timing Info:     ENABLED
+         Forwarding:            DISABLED
+
+Instruction Counts:
+
+        Total number of instructions:   911
+        Arithmetic instructions:        375
+        Logical instructions:           61
+        Memory Access instructions:     300
+        Control Flow instructions:      175
+
+Final Register State:
+
+        Program Counter:        112
+        R11: 1044
+        R12: 1836
+        R13: 2640
+        R14: 25
+        R15: 4294967108
+        R16: 213
+        R17: 29
+        R18: 3440
+        R19: 4294967295
+        R20: 4294967294
+        R21: 4294967295
+        R22: 76
+        R23: 3
+        R24: 4294967295
+        R25: 3
+        Total Stalls:   554
+        Address: 2400, Contents: 2
+        Address: 2404, Contents: 4
+        Address: 2408, Contents: 6
+        Address: 2412, Contents: 8
+        Address: 2416, Contents: 10
+        Address: 2420, Contents: 12
+        Address: 2424, Contents: 14
+        Address: 2428, Contents: 16
+        Address: 2432, Contents: 18
+        Address: 2436, Contents: 29
+        Address: 2440, Contents: 22
+        Address: 2444, Contents: 24
+        Address: 2448, Contents: 26
+        Address: 2452, Contents: 28
+        Address: 2456, Contents: 30
+        Address: 2460, Contents: 32
+        Address: 2464, Contents: 34
+        Address: 2468, Contents: 36
+        Address: 2472, Contents: 38
+        Address: 2476, Contents: 59
+        Address: 2480, Contents: 42
+        Address: 2484, Contents: 44
+        Address: 2488, Contents: 46
+        Address: 2492, Contents: 48
+        Address: 2496, Contents: 50
+        Address: 2500, Contents: 52
+        Address: 2504, Contents: 54
+        Address: 2508, Contents: 56
+        Address: 2512, Contents: 58
+        Address: 2516, Contents: 89
+        Address: 2520, Contents: 62
+        Address: 2524, Contents: 64
+        Address: 2528, Contents: 66
+        Address: 2532, Contents: 68
+        Address: 2536, Contents: 70
+        Address: 2540, Contents: 72
+        Address: 2544, Contents: 74
+        Address: 2548, Contents: 76
+        Address: 2552, Contents: 78
+        Address: 2556, Contents: 119
+        Address: 2560, Contents: 82
+        Address: 2564, Contents: 84
+        Address: 2568, Contents: 86
+        Address: 2572, Contents: 88
+        Address: 2576, Contents: 90
+        Address: 2580, Contents: 92
+        Address: 2584, Contents: 94
+        Address: 2588, Contents: 96
+        Address: 2592, Contents: 98
+        Address: 2596, Contents: 149
+        Address: 2600, Contents: 2
+        Address: 2604, Contents: 4
+        Address: 2608, Contents: 6
+        Address: 2612, Contents: 8
+        Address: 2616, Contents: 10
+        Address: 2620, Contents: 12
+        Address: 2624, Contents: 14
+        Address: 2628, Contents: 16
+        Address: 2632, Contents: 18
+        Address: 2636, Contents: 29
+
+Timing Simulator:
+
+        Total number of clock cycles: 1707
+
+MIPS-lite on  main [?] via △ v4.0.2 
+❯ ./build/Debug/bin/mips_simulator -i traces/hex/final-demo.txt -t -f
+Current Settings: 
+         Input Filepath:        traces/hex/final-demo.txt
+         Output Filepath:       output/traceout.txt
+         Print Memory Contents: DISABLED
+         Print Timing Info:     ENABLED
+         Forwarding:            ENABLED
+
+Instruction Counts:
+
+        Total number of instructions:   911
+        Arithmetic instructions:        375
+        Logical instructions:           61
+        Memory Access instructions:     300
+        Control Flow instructions:      175
+
+Final Register State:
+
+        Program Counter:        112
+        R11: 1044
+        R12: 1836
+        R13: 2640
+        R14: 25
+        R15: 4294967108
+        R16: 213
+        R17: 29
+        R18: 3440
+        R19: 4294967295
+        R20: 4294967294
+        R21: 4294967295
+        R22: 76
+        R23: 3
+        R24: 4294967295
+        R25: 3
+        Total Stalls:   60
+        Address: 2400, Contents: 2
+        Address: 2404, Contents: 4
+        Address: 2408, Contents: 6
+        Address: 2412, Contents: 8
+        Address: 2416, Contents: 10
+        Address: 2420, Contents: 12
+        Address: 2424, Contents: 14
+        Address: 2428, Contents: 16
+        Address: 2432, Contents: 18
+        Address: 2436, Contents: 29
+        Address: 2440, Contents: 22
+        Address: 2444, Contents: 24
+        Address: 2448, Contents: 26
+        Address: 2452, Contents: 28
+        Address: 2456, Contents: 30
+        Address: 2460, Contents: 32
+        Address: 2464, Contents: 34
+        Address: 2468, Contents: 36
+        Address: 2472, Contents: 38
+        Address: 2476, Contents: 59
+        Address: 2480, Contents: 42
+        Address: 2484, Contents: 44
+        Address: 2488, Contents: 46
+        Address: 2492, Contents: 48
+        Address: 2496, Contents: 50
+        Address: 2500, Contents: 52
+        Address: 2504, Contents: 54
+        Address: 2508, Contents: 56
+        Address: 2512, Contents: 58
+        Address: 2516, Contents: 89
+        Address: 2520, Contents: 62
+        Address: 2524, Contents: 64
+        Address: 2528, Contents: 66
+        Address: 2532, Contents: 68
+        Address: 2536, Contents: 70
+        Address: 2540, Contents: 72
+        Address: 2544, Contents: 74
+        Address: 2548, Contents: 76
+        Address: 2552, Contents: 78
+        Address: 2556, Contents: 119
+        Address: 2560, Contents: 82
+        Address: 2564, Contents: 84
+        Address: 2568, Contents: 86
+        Address: 2572, Contents: 88
+        Address: 2576, Contents: 90
+        Address: 2580, Contents: 92
+        Address: 2584, Contents: 94
+        Address: 2588, Contents: 96
+        Address: 2592, Contents: 98
+        Address: 2596, Contents: 149
+        Address: 2600, Contents: 2
+        Address: 2604, Contents: 4
+        Address: 2608, Contents: 6
+        Address: 2612, Contents: 8
+        Address: 2616, Contents: 10
+        Address: 2620, Contents: 12
+        Address: 2624, Contents: 14
+        Address: 2628, Contents: 16
+        Address: 2632, Contents: 18
+        Address: 2636, Contents: 29
+
+Timing Simulator:
+
+        Total number of clock cycles: 1213
+
+MIPS-lite on  main [?] via △ v4.0.2 
+❯ 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,17 +1,17 @@
-#include <iostream>
-#include <string>
-#include <stdexcept>
-#include <unordered_set>
-#include <set>
 #include <filesystem>
+#include <iostream>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
 
 // Program Libraries
 #include "functional_simulator.h"
-#include "stats.h"
+#include "mips_instruction.h"
+#include "mips_lite_defs.h"
 #include "mips_mem_parser.h"
 #include "register_file.h"
-#include "mips_lite_defs.h"
-#include "mips_instruction.h"
+#include "stats.h"
 
 const uint32_t timeout_cycles_ = 100000;
 
@@ -24,8 +24,7 @@ const uint32_t timeout_cycles_ = 100000;
  * @param -f: Enables forwarding for functional simulator
  * @throws std::invalid_arguement if program is passed invalid values
  */
-int main (int argc, char* argv[]) {
-
+int main(int argc, char* argv[]) {
     std::string input_tracename_, output_tracename_;
 
     // Default settings for no args
@@ -43,48 +42,51 @@ int main (int argc, char* argv[]) {
             // Check if next arg exists and check if next arg is not an flag
             if (i + 1 >= argc) {
                 throw std::invalid_argument("Output filepath must be provided after -i argument.");
-            } else if (argv[i+1][0] == '-') {
+            } else if (argv[i + 1][0] == '-') {
                 throw std::invalid_argument("Missing filepath after -i argument.");
             }
 
-            input_tracename_ = argv[i+1];   // Saves input filepath into inFile
+            input_tracename_ = argv[i + 1];  // Saves input filepath into inFile
 
             // Verify that path to file exists
             if (!std::filesystem::exists(input_tracename_)) {
-                throw std::invalid_argument("Input file \"" + input_tracename_ +"\" does not exists.");
+                throw std::invalid_argument("Input file \"" + input_tracename_ +
+                                            "\" does not exists.");
             }
 
-            i++;                            // Skips arg with filepath
+            i++;  // Skips arg with filepath
         } else if (arg == "-o") {
             // Check if next arg exists and check if next arg is not an flag
             if (i + 1 >= argc) {
                 throw std::invalid_argument("Output filepath must be provided after -o argument.");
-            } else if (argv[i+1][0] == '-') {
+            } else if (argv[i + 1][0] == '-') {
                 throw std::invalid_argument("Missing filepath after -o argument.");
             }
-            output_tracename_ = argv[i+1];  // Saves output filepath into outFile
-            enable_mem_save_ = true;        // Enable memory save to file
-            i++;                            // Skips arg with filepath
+            output_tracename_ = argv[i + 1];  // Saves output filepath into outFile
+            enable_mem_save_ = true;          // Enable memory save to file
+            i++;                              // Skips arg with filepath
         } else if (arg == "-m") {
-            enable_mem_print_ = true;       // Enable memory print to stdout
+            enable_mem_print_ = true;  // Enable memory print to stdout
         } else if (arg == "-t") {
-            time_info_ = true;              // Enable printing of timing information
+            time_info_ = true;  // Enable printing of timing information
         } else if (arg == "-f") {
-            forward_ = true;                // Enable forwarding for functional simulator
+            forward_ = true;  // Enable forwarding for functional simulator
         } else {
-            throw std::invalid_argument("Argument \"" + arg + "\" to program is invalid, try again.");
+            throw std::invalid_argument("Argument \"" + arg +
+                                        "\" to program is invalid, try again.");
         }
     }
 
-    // Print Current Settings to stdout
-    #ifdef DEBUG_MODE
+// Print Current Settings to stdout
+#ifdef DEBUG_MODE
     std::cout << "Current Settings: " << "\n";
     std::cout << "\t Input Filepath:\t" << input_tracename_ << "\n";
     std::cout << "\t Output Filepath:\t" << output_tracename_ << "\n";
-    std::cout << "\t Print Memory Contents:\t" << (enable_mem_print_ ? "ENABLED" : "DISABLED") << "\n";
+    std::cout << "\t Print Memory Contents:\t" << (enable_mem_print_ ? "ENABLED" : "DISABLED")
+              << "\n";
     std::cout << "\t Print Timing Info:\t" << (time_info_ ? "ENABLED" : "DISABLED") << "\n";
     std::cout << "\t Forwarding:\t\t" << (forward_ ? "ENABLED" : "DISABLED") << "\n";
-    #endif
+#endif
 
     // Create Stats, Register File, and Memory Parser class instance
     Stats stats;
@@ -95,10 +97,10 @@ int main (int argc, char* argv[]) {
     std::unique_ptr<FunctionalSimulator> fs;
     fs = std::make_unique<FunctionalSimulator>(&rf, &stats, &mp, forward_);
 
-    while(!fs->isProgramFinished()){
+    while (!fs->isProgramFinished()) {
         fs->cycle();
 
-        if(stats.getClockCycles() >= timeout_cycles_) {
+        if (stats.getClockCycles() >= timeout_cycles_) {
             std::cerr << "Simulator did not halt within " << timeout_cycles_ << " cycles" << "\n";
             break;
         }
@@ -117,11 +119,22 @@ int main (int argc, char* argv[]) {
 
     // Print Instruction Counts
     std::cout << "\nInstruction Counts:\n\n";
-    std::cout << "\tTotal number of instructions:\t" << std::to_string(stats.totalInstructions()) << "\n";
-    std::cout << "\tArithmetic instructions:\t" << std::to_string(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC)) << "\n";
-    std::cout << "\tLogical instructions:\t\t" << std::to_string(stats.getCategoryCount(mips_lite::InstructionCategory::LOGICAL)) << "\n";
-    std::cout << "\tMemory Access instructions:\t" << std::to_string(stats.getCategoryCount(mips_lite::InstructionCategory::MEMORY_ACCESS)) << "\n";
-    std::cout << "\tControl Flow instructions:\t" << std::to_string(stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW)) << "\n";
+    std::cout << "\tTotal number of instructions:\t" << std::to_string(stats.totalInstructions())
+              << "\n";
+    std::cout << "\tArithmetic instructions:\t"
+              << std::to_string(stats.getCategoryCount(mips_lite::InstructionCategory::ARITHMETIC))
+              << "\n";
+    std::cout << "\tLogical instructions:\t\t"
+              << std::to_string(stats.getCategoryCount(mips_lite::InstructionCategory::LOGICAL))
+              << "\n";
+    std::cout << "\tMemory Access instructions:\t"
+              << std::to_string(
+                     stats.getCategoryCount(mips_lite::InstructionCategory::MEMORY_ACCESS))
+              << "\n";
+    std::cout << "\tControl Flow instructions:\t"
+              << std::to_string(
+                     stats.getCategoryCount(mips_lite::InstructionCategory::CONTROL_FLOW))
+              << "\n";
 
     // Print Final Register State
     std::set<uint8_t> final_registers_(stats.getRegisters().begin(), stats.getRegisters().end());
@@ -133,7 +146,8 @@ int main (int argc, char* argv[]) {
 
     // Print registers that have been used
     for (auto item = final_registers_.begin(); item != final_registers_.end(); item++) {
-        std::cout << "\tR" << std::to_string(*item) << ": " << std::to_string(rf.read(*item)) << "\n";
+        std::cout << "\tR" << std::to_string(*item) << ": "
+                  << std::to_string(static_cast<int32_t>(rf.read(*item))) << "\n";
     }
 
     // Print Total Number of Stalls
@@ -142,18 +156,21 @@ int main (int argc, char* argv[]) {
     }
 
     // Print Final Memory State
-    std::set<uint32_t> final_memory_(stats.getMemoryAddresses().begin(), stats.getMemoryAddresses().end());
+    std::set<uint32_t> final_memory_(stats.getMemoryAddresses().begin(),
+                                     stats.getMemoryAddresses().end());
 
     // Print memory locations and values that have been accessed
     for (auto item = final_memory_.begin(); item != final_memory_.end(); item++) {
-        std::cout << "\tAddress: " << std::to_string(*item) << ", Contents: " << std::to_string(mp.readMemory(*item)) << "\n";
+        std::cout << "\tAddress: " << std::to_string(*item)
+                  << ", Contents: " << std::to_string(mp.readMemory(*item)) << "\n";
     }
 
     // Print timing info if enabled
     if (time_info_) {
         std::cout << "\nTiming Simulator:\n\n";
-        std::cout << "\tTotal number of clock cycles: " << std::to_string(stats.getClockCycles()) << "\n";
-    } 
+        std::cout << "\tTotal number of clock cycles: " << std::to_string(stats.getClockCycles())
+                  << "\n";
+    }
 
     return 0;
 }


### PR DESCRIPTION
Many of these changes are because of clang format. The only functional change I made was to the register printing in main.cpp by adding a static cast:
```cpp
// Print registers that have been used
    for (auto item = final_registers_.begin(); item != final_registers_.end(); item++) {
        std::cout << "\tR" << std::to_string(*item) << ": "
                  << std::to_string(static_cast<int32_t>(rf.read(*item))) << "\n";
    }
```